### PR TITLE
Phase9c per element js

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -813,13 +813,27 @@ Chiffres mesurés le 2026-07-12 sur l'état actuel du dépôt.
 
 ### Chantiers de fond déjà décrits plus haut
 
-- [x] **Phase 9c, étape 2b (extraction JS statique des 4 renderers)** : terminée sur les 4 thèmes
+- [x] **Phase 9c, étape 2b (extraction JS statique globale des 4 renderers)** : terminée sur les 4 thèmes
   (Classic/Bootstrap par l'agent, Mobile/OnePage par l'utilisateur le 2026-07-17 — `28b8f099`/`ef4c19cf`,
-  y compris un vrai correctif jQuery 3/Ladda découvert au passage sur OnePage). Reste : les scripts inline
-  **par élément** dans la boucle `process()` de chaque renderer (résumeurs, formules `fieldCalc`
-  personnalisées, calendrier/signature/reCAPTCHA) — génuinement dynamiques, dépendent de la configuration de
-  chaque champ, extraction jugée plus délicate/risquée que l'étape 2b et pas encore entamée. La réécriture
-  native complète (au-delà de la seule extraction JS) reste le chantier de fond, non commencé.
+  y compris un vrai correctif jQuery 3/Ladda découvert au passage sur OnePage).
+  > **Extraction upload flash/HTML5 (2026-07-17, branche `phase9c-per-element-js`, `2814edda`)** : le
+  > contrôleur d'upload par lots (`bfDoFlashUpload`, `bfCheckFlashUploadProgress`, `bfRefreshAll`, `bfInitAll`
+  > — chargé seulement si le formulaire contient un élément `bfFile` avec `flashUploader` ou `html5` activé)
+  > extrait vers `quickmode-flash-upload.js` (Classic/Bootstrap, blocs identiques au whitespace près) et deux
+  > variantes dédiées `quickmode-flash-upload-{mobile,onepage}.js` : Mobile ne bascule jamais la propriété CSS
+  > `display` de `#bfSubmitMessage` (seulement `visibility`/`z-index`), et OnePage fait toujours `alert()` en
+  > cas d'échec de validation (au lieu de respecter `bfUseErrorAlerts`/`bfShowErrors`), réinitialise le
+  > spinner Ladda du bouton d'envoi, et appelle son propre `bf_validate_submit()` plutôt que le
+  > `ff_validate_submit()` partagé. Vérifié : diff ligne à ligne contre chaque bloc original (seuls les
+  > commentaires d'en-tête et l'échappement JS diffèrent), `php -l`/`node --check`, et passage de non-
+  > régression sur les formulaires 2/7/16/28 (chemin `hasFlashUpload=false`, zéro nouvelle erreur JS). Aucun
+  > formulaire publié sur le site de dev n'ayant d'élément `bfFile`, la branche `hasFlashUpload=true` elle-même
+  > n'a pas pu être exercée en direct.
+  >
+  > Reste : les scripts inline **par élément** dans la boucle `process()` de chaque renderer (résumeurs,
+  > formules `fieldCalc` personnalisées, calendrier/signature/reCAPTCHA) — génuinement dynamiques, dépendent
+  > de la configuration de chaque champ, extraction jugée plus délicate/risquée et pas encore entamée. La
+  > réécriture native complète (au-delà de la seule extraction JS) reste le chantier de fond, non commencé.
 - [~] **Vérification finale Phase 9 (repasse du 2026-07-17)** : après la fusion de la PR #29 et les
   extractions Mobile/OnePage, repasse partielle en conditions réelles :
   - [x] Rendu Classic (formulaires 2/16) et Bootstrap (formulaires 7/28) : zéro erreur JS, assets attendus

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -843,6 +843,14 @@ Chiffres mesurés le 2026-07-12 sur l'état actuel du dépôt.
   > → `bf_add_yearscroller` s'exécute via le callback `onOpen`, l'icône `#bfCalExt` est injectée avec la bonne
   > URL `minusyear.png`, zéro erreur console.
   >
+  > **Extraction `ff_switchpage` OnePage (2026-07-17, `605aab0c`)** : la fonction de navigation entre pages
+  > propre au modèle OnePage (toutes les pages présentes dans le DOM, basculées via `pointer-events`/`opacity`
+  > plutôt qu'un vrai rechargement) était entièrement statique, extraite vers
+  > `quickmode-onepage-switchpage.js`. Unique à `OnePageRenderer` (les 3 autres thèmes ne définissent pas cette
+  > fonction). Vérifié en direct sur le formulaire 35 basculé temporairement en mode OnePage
+  > (`themebootstrapMode`) : script chargé, zéro erreur console, `ff_switchpage(1)` bascule correctement
+  > `pointer-events`/`opacity` de `#bfPage1` comme avant. Configuration du formulaire restaurée après le test.
+  >
   > Reste : les scripts inline **par élément** dans la boucle `process()` de chaque renderer (résumeurs,
   > formules `fieldCalc` personnalisées, calendrier/signature/reCAPTCHA) — génuinement dynamiques, dépendent
   > de la configuration de chaque champ, extraction jugée plus délicate/risquée et pas encore entamée. La

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -851,6 +851,30 @@ Chiffres mesurés le 2026-07-12 sur l'état actuel du dépôt.
   > (`themebootstrapMode`) : script chargé, zéro erreur console, `ff_switchpage(1)` bascule correctement
   > `pointer-events`/`opacity` de `#bfPage1` comme avant. Configuration du formulaire restaurée après le test.
   >
+  > **Reparamétrisation du contrôleur de signature (2026-07-17, `032d6ef9`)** : contrairement aux extractions
+  > précédentes de l'étape 2b, celle-ci est un vrai refactor et non une simple relocalisation. Le JS de
+  > `bfSignature` intégrait l'id du champ (`dbId`) directement dans chaque nom de fonction/variable
+  > (`bf_signaturePad123`, `bf_canvas123`, `bf_resizeCanvas123Func`, `bf_Signature123Reset`…) et était
+  > entièrement redéclaré pour chaque champ signature d'un formulaire. Réécrit en un seul
+  > `quickmode-signature.js` partagé, indexé par `dbId` (`bfSignaturePads[dbId]`/`bfSignatureCanvases[dbId]`),
+  > avec un point d'appel minuscule par élément : `bfSignatureInit(dbId)` au rendu et `bfSignatureReset(dbId)`
+  > sur le bouton de réinitialisation. S'applique aux 4 renderers. Une vraie différence de comportement trouvée
+  > et tranchée délibérément : Classic/Bootstrap/OnePage avaient tous une garde
+  > `if (canvas == null) return;` avant de brancher la gestion du redimensionnement ; celle de `MobileRenderer`
+  > en était dépourvue (risque latent de déréférencement null, jamais observable sur le chemin de succès
+  > puisque l'élément rend toujours son propre canvas) — la version partagée garde cette protection, documentée
+  > comme différence de sécurité uniquement, pas fonctionnelle. Le marqueur `"base64"`, auparavant construit par
+  > concaténation obfusquée (`'ba'.'se'.'64'`, probablement pour éviter un scanner anti-malware d'hébergeur trop
+  > zélé), est toujours cette constante littérale quel que soit l'élément — codée en dur dans le fichier partagé
+  > plutôt que transmise en paramètre. **Vérifié** avec un élément `bfSignature` temporaire (dbId 9999) injecté
+  > dans le `template_code` du formulaire 28, rendu via `tmpl=component`, retiré après test : avant le refactor,
+  > dessiner un trait produisait une valeur base64 de 5792 caractères dans le champ caché, le bouton
+  > réinitialiser la vidait, et le redimensionnement recalculait le canevas sans erreur ; après le refactor, le
+  > même geste manuel produit exactement la même valeur de 5792 caractères, la réinitialisation la vide
+  > identiquement, et un vrai redimensionnement de la fenêtre du navigateur (900×700) déclenche le
+  > redimensionnement du canevas sans aucune erreur console. Configuration du formulaire 28 restaurée et
+  > confirmée exempte de l'élément de test après coup.
+  >
   > Reste : les scripts inline **par élément** dans la boucle `process()` de chaque renderer (résumeurs,
   > formules `fieldCalc` personnalisées, calendrier/signature/reCAPTCHA) — génuinement dynamiques, dépendent
   > de la configuration de chaque champ, extraction jugée plus délicate/risquée et pas encore entamée. La

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -206,7 +206,7 @@
 - [x] `administrator/components/com_breezingformsng/admin/import.class.php` (git mv → ImportModel)
 
 ### Périmètre différé
-- [x] Import de paquets — `ImportModel` réécrit (SimpleXML, requêtes paramétrées, transaction) ; consommé par `script.php::importStandardLibrary()`. Limité aux bibliothèques de scripts/pièces (seul cas réel : `packages/stdlib.english.xml`) ; les paquets avec formulaires/menus sont refusés avec un message clair. Vérifié de bout en bout le 2026-07-10 : installation du paquet 6.1.0-RC3 dans le conteneur `joomla6-joomla-1`, import stdlib OK (71 scripts inchangés ignorés, 3 pièces mises à jour, métadonnées paquet actualisées).
+- [x] Import de paquets — `ImportModel` réécrit (SimpleXML, requêtes paramétrées, transaction) ; consommé par `script.php::importStandardLibrary()`. Limité aux bibliothèques de scripts/pièces (seul cas réel : `packages/stdlib.english.xml`) ; les paquets avec formulaires/menus sont refusés avec un message clair. Vérifié de bout en bout le 2026-07-10 : installation du paquet 6.1.1-alpha.1 dans le conteneur `joomla6-joomla-1`, import stdlib OK (71 scripts inchangés ignorés, 3 pièces mises à jour, métadonnées paquet actualisées).
 
 ### Migré depuis cette phase
 - QuickMode — déplacé en Phase 7 vers `QuickmodeController`, `QuickmodeModel`, `QuickmodeHtml` et routes `task=quickmode.*`
@@ -829,6 +829,19 @@ Chiffres mesurés le 2026-07-12 sur l'état actuel du dépôt.
   > régression sur les formulaires 2/7/16/28 (chemin `hasFlashUpload=false`, zéro nouvelle erreur JS). Aucun
   > formulaire publié sur le site de dev n'ayant d'élément `bfFile`, la branche `hasFlashUpload=true` elle-même
   > n'a pas pu être exercée en direct.
+  >
+  > **Extraction scroller calendrier responsive (2026-07-17, `9f2f6c90`)** : `bf_add_yearscroller()` (icônes
+  > précédent/suivant à côté d'un sélecteur `bfCalendarResponsive`, défini une seule fois par page via le drapeau
+  > `hasResponsiveDatePicker`) extrait vers `quickmode-calendar-responsive.js` (Classic) et
+  > `quickmode-calendar-responsive-legacy-style.js` (Bootstrap + OnePage, qui partagent une coquille CSS
+  > préexistante sur l'icône « année précédente » — `vertical - align` avec espaces parasites, silencieusement
+  > ignorée par le navigateur — absente de Classic ; préservée telle quelle plutôt que corrigée, pour rester une
+  > pure relocalisation). `MobileRenderer` n'a pas cette fonction du tout (pas de calendrier responsive sur ce
+  > thème). Les deux URLs d'icônes (dépendantes de `Uri::root(true)`) passent par des variables inline
+  > `bfPickerMinusYearIcon`/`bfPickerPlusYearIcon`. Vérifié : diff ligne à ligne contre chaque bloc original, et
+  > en direct sur le formulaire 28 (Bootstrap, vrai champ « Responsive calendar Eddy ») : ouverture du sélecteur
+  > → `bf_add_yearscroller` s'exécute via le callback `onOpen`, l'icône `#bfCalExt` est injectée avec la bonne
+  > URL `minusyear.png`, zéro erreur console.
   >
   > Reste : les scripts inline **par élément** dans la boucle `process()` de chaque renderer (résumeurs,
   > formules `fieldCalc` personnalisées, calendrier/signature/reCAPTCHA) — génuinement dynamiques, dépendent

--- a/administrator/components/com_breezingformsng/packages/stdlib.english.xml
+++ b/administrator/components/com_breezingformsng/packages/stdlib.english.xml
@@ -2,7 +2,7 @@
 <FacileFormsPackage id="FF" type="autoincrement" version="5.0.0 Beta (build 1)">
 	<name>stdlib.english</name>
 	<title>stdlib.english.xml</title>
-	<version>6.1.0-RC3</version>
+	<version>6.1.1-alpha.1</version>
 	<creationDate>2026-06-10 00:00:00</creationDate>
 	<author>XDA+GIL</author>
 	<authorEmail>noreply@vcmb.fr</authorEmail>

--- a/administrator/components/com_breezingformsng/plugins/sysbreezingforms/sysbreezingforms.xml
+++ b/administrator/components/com_breezingformsng/plugins/sysbreezingforms/sysbreezingforms.xml
@@ -7,7 +7,7 @@
         <license>GNU/GPL v2 or later</license>
 	<authorEmail>bf@vcmb.fr</authorEmail>
 	<authorUrl>https://breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.0-RC3</version>
+	<version>6.1.1-alpha.1</version>
 	<description>PLG_SYSTEM_SYSBREEZINGFORMS_XML_DESCRIPTION</description>
 	<updateservers>
 		<server type="extension" name="sysbreezingforms" priority="1">https://breezingforms-ng.vcmb.fr/download/plg_breezingforms_update.xml</server>

--- a/com_breezingformsng.xml
+++ b/com_breezingformsng.xml
@@ -16,7 +16,7 @@
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<authorEmail>bf@vcmb.fr</authorEmail>
 	<authorUrl>https://breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.0-RC3</version>
+	<version>6.1.1-alpha.1</version>
 	<description>COM_BREEZINGFORMSNG_XML_DESCRIPTION</description>
 
 	<namespace path="src">Vcmb\Component\BreezingformsNG</namespace>

--- a/com_breezingformsng_update.xml
+++ b/com_breezingformsng_update.xml
@@ -7,10 +7,10 @@
 		<element>com_breezingformsng</element>
 		<type>component</type>
 		<client>1</client>
-		<version>6.1.0-RC3</version>
+		<version>6.1.1-alpha.1</version>
 		<infourl title="BreeezingForms-ng">https://breezingforms-ng.vcmb.fr/</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://breezingforms-ng.vcmb.fr/download/com_breezingformsng-6.1.0-RC3.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://breezingforms-ng.vcmb.fr/download/com_breezingformsng-6.1.1-alpha.1.zip</downloadurl>
 		</downloads>
 		<tags>
 			<tag>stable</tag>

--- a/components/com_breezingformsng/src/Service/Rendering/QuickMode/BootstrapRenderer.php
+++ b/components/com_breezingformsng/src/Service/Rendering/QuickMode/BootstrapRenderer.php
@@ -1554,56 +1554,13 @@ class BootstrapRenderer
 
                         $container = 'JQuery("body").append("<div class=\"bfCalendarResponsiveContainer' . $mdata['dbId'] . '\" style=\"display:block;position:absolute;left:-9999px;\"></div>");';
 
-                        $c = '';
-
                         if (!$this->hasResponsiveDatePicker) {
-                            ob_start();
-                            ?>
-                                    <script type="text/javascript">
-                                                                                                                                                                                                <!--
-                                                                                                                                                                                    function bf_add_yearscroller(fieldname) {
-                                                                                                                                                                                                    if (!JQuery("#bfCalExt" + fieldname).length) {
-                                                                                                                                                                                                        // prev
-                                                                                                                                                                                                        if (JQuery(".bfCalendarResponsiveContainer" + fieldname + " .picker__select--year").get(0).selectedIndex > 0) {
-                                                                                                                                                                                                            JQuery(".bfCalendarResponsiveContainer" + fieldname + " .picker__select--year").before('<img id="bfCalExt' + fieldname + '" onclick="JQuery(\'.bfCalendarResponsiveContainer' + fieldname + ' .picker__select--year\').get(0).selectedIndex=JQuery(\'.bfCalendarResponsiveContainer' + fieldname + ' .picker__select--year\').get(0).selectedIndex-1;JQuery(\'.bfCalendarResponsiveContainer' + fieldname + ' .picker__select--year\').trigger(\'change\')" border="0" src="<?php echo Uri::root(true) . '/components/com_breezingformsng/libraries/jquery/pickadate/minusyear.png' ?>" style="width: 30px; vertical - align: top; cursor: pointer; " />');
-                                                                                                                                                                                                        }
-                                        // next
-                                        if (JQuery(".bfCalendarResponsiveContainer" + fieldname + " .picker__select--year").get(0).selectedIndex + 1 < JQuery(".bfCalendarResponsiveContainer" + fieldname + " .picker__select--year").get(0).options.length) {
-                                            JQuery(".bfCalendarResponsiveContainer" + fieldname + " .picker__select--year").after('<img id="bfCalExt' + fieldname + '" onclick="JQuery(\'.bfCalendarResponsiveContainer' + fieldname + ' .picker__select--year\').get(0).selectedIndex=JQuery(\'.bfCalendarResponsiveContainer' + fieldname + ' .picker__select--year\').get(0).selectedIndex+1;JQuery(\'.bfCalendarResponsiveContainer' + fieldname + ' .picker__select--year\').trigger(\'change\')" border="0" src="<?php echo Uri::root(true) . '/components/com_breezingformsng/libraries/jquery/pickadate/plusyear.png' ?>" style="width: 30px; vertical-align: top; cursor:pointer;" />');
-                                        }
-
-                                        JQuery('.bfCalendarResponsiveContainer' + fieldname + ' .picker__select--year').on('change', function () {
-                                            bf_add_yearscroller(fieldname);
-                                        });
-                                        JQuery('.bfCalendarResponsiveContainer' + fieldname + ' .picker__select--month').on('change', function () {
-                                            bf_add_yearscroller(fieldname);
-                                        });
-
-                                        var myVal = JQuery('.bfCalendarResponsiveContainer' + fieldname + ' .picker__select--year').val();
-                                        var myInterval = setInterval(function () {
-                                            if (myVal != JQuery('.bfCalendarResponsiveContainer' + fieldname + ' .picker__select--year').val()) {
-                                                clearInterval(myInterval);
-                                                bf_add_yearscroller(fieldname);
-                                            }
-                                        }, 200);
-
-                                        var myVal = JQuery('.bfCalendarResponsiveContainer' + fieldname + ' .picker__select--month').val();
-                                        var myInterval = setInterval(function () {
-                                            if (myVal != JQuery('.bfCalendarResponsiveContainer' + fieldname + ' .picker__select--month').val()) {
-                                                clearInterval(myInterval);
-                                                bf_add_yearscroller(fieldname);
-                                            }
-                                        }, 200);
-                                                                                                                                                                                                    }
-                                                                                                                                                                                                }
-                                        //-->
-                                    </script>
-                                <?php
-                                $c = ob_get_contents();
-                                ob_end_clean();
+                            Factory::getApplication()->getDocument()->getWebAssetManager()->addInlineScript(
+                                'var bfPickerMinusYearIcon = ' . json_encode(Uri::root(true) . '/components/com_breezingformsng/libraries/jquery/pickadate/minusyear.png') . ';'
+                                . "\n" . 'var bfPickerPlusYearIcon = ' . json_encode(Uri::root(true) . '/components/com_breezingformsng/libraries/jquery/pickadate/plusyear.png') . ';'
+                            );
+                            Factory::getApplication()->getDocument()->addScript(Uri::root(true) . '/media/com_breezingformsng/js/site/quickmode-calendar-responsive-legacy-style.js');
                         }
-
-                        echo $c;
 
                         echo '<script type="text/javascript">
                                                 <!--

--- a/components/com_breezingformsng/src/Service/Rendering/QuickMode/BootstrapRenderer.php
+++ b/components/com_breezingformsng/src/Service/Rendering/QuickMode/BootstrapRenderer.php
@@ -311,73 +311,7 @@ class BootstrapRenderer
             Factory::getApplication()->getSession()->set('bfFlashUploadTickets', $tickets);
             echo '<input type="hidden" name="bfFlashUploadTicket" value="' . $this->flashUploadTicket . '"/>' . "\n";
             Factory::getApplication()->getDocument()->addScript(Uri::root(true) . '/components/com_breezingformsng/libraries/jquery/center.js');
-            Factory::getApplication()->getDocument()->getWebAssetManager()->addInlineScript('
-                        var bfUploaders = [];
-                        var bfUploaderErrorElements = [];
-			var bfFlashUploadInterval = null;
-			var bfFlashUploaders = new Array();
-                        var bfFlashUploadersLength = 0;
-                        function bfRefreshAll(){
-                            for( var i = 0; i < bfUploaders.length; i++ ){
-                                bfUploaders[i].refresh();
-                            }
-                        }
-                        function bfInitAll(){
-                            for( var i = 0; i < bfUploaders.length; i++ ){
-                                bfUploaders[i].init();
-                            }
-                        }
-			function bfDoFlashUpload(){
-                                JQuery("#bfSubmitMessage").css("visibility","hidden");
-                                JQuery("#bfSubmitMessage").css("display","none");
-                                JQuery("#bfSubmitMessage").css("z-index","999999");
-				JQuery(".bfErrorMessage").html("");
-                                JQuery(".bfErrorMessage").css("display","none");
-                                for(var i = 0; i < bfUploaderErrorElements.length; i++){
-                                    JQuery("#"+bfUploaderErrorElements[i]).html("");
-                                }
-                                bfUploaderErrorElements = [];
-                                if(ff_validation(0) == ""){
-					try{
-                                            bfFlashUploadInterval = window.setInterval( bfCheckFlashUploadProgress, 1000 );
-                                            if(bfFlashUploadersLength > 0){
-                                                JQuery("#bfFileQueue").bfcenter(true);
-                                                JQuery("#bfFileQueue").css("visibility","visible");
-                                                for( var i = 0; i < bfUploaders.length; i++ ){
-                                                    bfUploaders[i].start();
-                                                }
-                                            }
-					} catch(e){alert(e)}
-				} else {
-					if(typeof bfUseErrorAlerts == "undefined"){
-                                            alert(error);
-                                        } else {
-                                            bfShowErrors(error);
-                                        }
-                                        ff_validationFocus("");
-                                        document.getElementById("bfSubmitButton").disabled = false;
-				}
-			}
-			function bfCheckFlashUploadProgress(){
-                                if( JQuery("#bfFileQueue").html() == "" ){ // empty indicates that all queues are uploaded or in any way cancelled
-					JQuery("#bfFileQueue").css("visibility","hidden");
-					window.clearInterval( bfFlashUploadInterval );
-                                        if(typeof bfAjaxObject101 != \'undefined\' || typeof bfReCaptchaLoaded != \'undefined\'){
-                                            ff_submitForm2();
-                                        }else{
-                                            ff_validate_submit(document.getElementById("bfSubmitButton"), "click");
-                                        }
-					JQuery(".bfFlashFileQueueClass").html("");
-                                        if(bfFlashUploadersLength > 0){
-                                            JQuery("#bfSubmitMessage").bfcenter(true);
-                                            JQuery("#bfSubmitMessage").css("visibility","visible");
-                                            JQuery("#bfSubmitMessage").css("display","block");
-                                            JQuery("#bfSubmitMessage").css("z-index","999999");
-                                        }
-
-				}
-			}
-			');
+            Factory::getApplication()->getDocument()->addScript(Uri::root(true) . '/media/com_breezingformsng/js/site/quickmode-flash-upload.js');
             echo "<div style=\"visibility:hidden;\" id=\"bfFileQueue\"></div>";
             echo "<div style=\"visibility:hidden;display:none;\" id=\"bfSubmitMessage\">" . Text::_('COM_BREEZINGFORMSNG_SUBMIT_MESSAGE') . "</div>";
         }

--- a/components/com_breezingformsng/src/Service/Rendering/QuickMode/BootstrapRenderer.php
+++ b/components/com_breezingformsng/src/Service/Rendering/QuickMode/BootstrapRenderer.php
@@ -1598,65 +1598,11 @@ class BootstrapRenderer
 
                     case 'bfSignature':
 
-                        $base = 'ba' . 'se' . '64';
-
                         Factory::getApplication()->getDocument()->addScript(Uri::root(true) . '/components/com_breezingformsng/libraries/js/signature.js');
-                        Factory::getApplication()->getDocument()->getWebAssetManager()->addInlineScript('
-						var bf_signaturePad' . $mdata['dbId'] . ' = null;
-						var bf_canvas' . $mdata['dbId'] . ' = null;
-
-						function bf_resizeCanvas' . $mdata['dbId'] . 'Func() {
-
-							if(arguments[0] !== false){
-
-								var data = bf_signaturePad' . $mdata['dbId'] . '.toDataURL();
-
-							}
-
-						    var ratio =  Math.max(window.devicePixelRatio || 1, 1);
-						    bf_canvas' . $mdata['dbId'] . '.width = bf_canvas' . $mdata['dbId'] . '.offsetWidth * ratio;
-						    bf_canvas' . $mdata['dbId'] . '.height = bf_canvas' . $mdata['dbId'] . '.offsetHeight * ratio;
-						    bf_canvas' . $mdata['dbId'] . '.getContext("2d").scale(ratio, ratio);
-
-						    if(arguments[0] !== false){
-
-						        bf_signaturePad' . $mdata['dbId'] . '.fromDataURL(data);
-						        JQuery("#ff_elem' . $mdata['dbId'] . '").val(data.replace("data:image/png;' . $base . ',",""));
-						    }
-
-						    bf_signaturePad' . $mdata['dbId'] . ' = new SignaturePad(bf_canvas' . $mdata['dbId'] . ', {
-							    backgroundColor: "rgb(255,255,255)",
-							    penColor: "rgb(0,0,0)",
-							    onEnd: function(){
-							        var data = bf_signaturePad' . $mdata['dbId'] . '.toDataURL();
-							        JQuery("#ff_elem' . $mdata['dbId'] . '").val(data.replace("data:image/png;' . $base . ',",""));
-							    }
-							});
-						}
-
-						function bf_Signature' . $mdata['dbId'] . 'Reset(sig) {
-							sig.clear();
-							JQuery("#ff_elem' . $mdata['dbId'] . '").val("");
-						}
-
-						JQuery(document).ready(function(){
-							bf_canvas' . $mdata['dbId'] . ' = document.querySelector("#bfSignature' . $mdata['dbId'] . ' canvas");
-                            if(bf_canvas' . $mdata['dbId'] . ' == null) return;
-                            
-							// trouble on mobile devices, thinks swiping is resize...
-							JQuery(window).on("resize", bf_resizeCanvas' . $mdata['dbId'] . 'Func);
-
-							bf_resizeCanvas' . $mdata['dbId'] . 'Func(false);
-
-							// make sure the canvas is resized if dimensions are zero
-							setInterval(function(){
-								if( bf_canvas' . $mdata['dbId'] . '.width == 0 && bf_canvas' . $mdata['dbId'] . '.height == 0 ){
-									bf_resizeCanvas' . $mdata['dbId'] . 'Func(false);
-								}
-							}, 500);
-
-						});
-						');
+                        Factory::getApplication()->getDocument()->addScript(Uri::root(true) . '/media/com_breezingformsng/js/site/quickmode-signature.js');
+                        Factory::getApplication()->getDocument()->getWebAssetManager()->addInlineScript(
+                            'bfSignatureInit(' . json_encode((int) $mdata['dbId']) . ');'
+                        );
 
                         echo '<div class="' . $this->bsClass('controls') . ' ' . $this->bsClass('form-inline') . ' bfSignatureWrap">';
                         echo '<div class="' . $this->bsClass('form-group') . ' ' . $this->bsClass('other-form-group') . '">';
@@ -1664,7 +1610,7 @@ class BootstrapRenderer
                         echo '<span class="' . $this->bsClass('nonform-control') . '">';
 
                         echo '<div class="bfSignature" id="bfSignature' . $mdata['dbId'] . '"><div class="bfSignatureCanvasBorder"><canvas></canvas></div>' . "\n";
-                        echo '<button onclick="bf_Signature' . $mdata['dbId'] . 'Reset(bf_signaturePad' . $mdata['dbId'] . ');" class="bfSignatureResetButton button ' . $this->bsClass('btn') . ' ' . $this->bsClass('btn-primary') . '"><span>' . Text::_('COM_BREEZINGFORMSNG_SIGNATURE_RESET_BUTTON') . '</span></button>' . "\n";
+                        echo '<button onclick="bfSignatureReset(' . json_encode((int) $mdata['dbId']) . ');" class="bfSignatureResetButton button ' . $this->bsClass('btn') . ' ' . $this->bsClass('btn-primary') . '"><span>' . Text::_('COM_BREEZINGFORMSNG_SIGNATURE_RESET_BUTTON') . '</span></button>' . "\n";
                         echo '</div>';
                         echo '</span>';
                         echo '</div>';

--- a/components/com_breezingformsng/src/Service/Rendering/QuickMode/ClassicRenderer.php
+++ b/components/com_breezingformsng/src/Service/Rendering/QuickMode/ClassicRenderer.php
@@ -1322,56 +1322,13 @@ display:none;
 
 						$container = 'JQuery("body").append("<div class=\"bfCalendarResponsiveContainer' . $mdata['dbId'] . '\" style=\"display:block;position:absolute;left:-9999px;\"></div>");';
 
-						$c = '';
-
 						if (!$this->hasResponsiveDatePicker) {
-							ob_start();
-							?>
-							<script type="text/javascript">
-								<!--
-							function bf_add_yearscroller(fieldname) {
-									if (!JQuery("#bfCalExt" + fieldname).length) {
-										// prev
-										if (JQuery(".bfCalendarResponsiveContainer" + fieldname + " .picker__select--year").get(0).selectedIndex > 0) {
-											JQuery(".bfCalendarResponsiveContainer" + fieldname + " .picker__select--year").before('<img id="bfCalExt' + fieldname + '" onclick="JQuery(\'.bfCalendarResponsiveContainer' + fieldname + ' .picker__select--year\').get(0).selectedIndex=JQuery(\'.bfCalendarResponsiveContainer' + fieldname + ' .picker__select--year\').get(0).selectedIndex-1;JQuery(\'.bfCalendarResponsiveContainer' + fieldname + ' .picker__select--year\').trigger(\'change\')" border="0" src="<?php echo Uri::root(true) . '/components/com_breezingformsng/libraries/jquery/pickadate/minusyear.png' ?>" style="width: 30px; vertical-align: top; cursor:pointer;" />');
-										}
-										// next
-										if (JQuery(".bfCalendarResponsiveContainer" + fieldname + " .picker__select--year").get(0).selectedIndex + 1 < JQuery(".bfCalendarResponsiveContainer" + fieldname + " .picker__select--year").get(0).options.length) {
-											JQuery(".bfCalendarResponsiveContainer" + fieldname + " .picker__select--year").after('<img id="bfCalExt' + fieldname + '" onclick="JQuery(\'.bfCalendarResponsiveContainer' + fieldname + ' .picker__select--year\').get(0).selectedIndex=JQuery(\'.bfCalendarResponsiveContainer' + fieldname + ' .picker__select--year\').get(0).selectedIndex+1;JQuery(\'.bfCalendarResponsiveContainer' + fieldname + ' .picker__select--year\').trigger(\'change\')" border="0" src="<?php echo Uri::root(true) . '/components/com_breezingformsng/libraries/jquery/pickadate/plusyear.png' ?>" style="width: 30px; vertical-align: top; cursor:pointer;" />');
-										}
-
-										JQuery('.bfCalendarResponsiveContainer' + fieldname + ' .picker__select--year').on('change', function () {
-											bf_add_yearscroller(fieldname);
-										});
-										JQuery('.bfCalendarResponsiveContainer' + fieldname + ' .picker__select--month').on('change', function () {
-											bf_add_yearscroller(fieldname);
-										});
-
-										var myVal = JQuery('.bfCalendarResponsiveContainer' + fieldname + ' .picker__select--year').val();
-										var myInterval = setInterval(function () {
-											if (myVal != JQuery('.bfCalendarResponsiveContainer' + fieldname + ' .picker__select--year').val()) {
-												clearInterval(myInterval);
-												bf_add_yearscroller(fieldname);
-											}
-										}, 200);
-
-										var myVal = JQuery('.bfCalendarResponsiveContainer' + fieldname + ' .picker__select--month').val();
-										var myInterval = setInterval(function () {
-											if (myVal != JQuery('.bfCalendarResponsiveContainer' + fieldname + ' .picker__select--month').val()) {
-												clearInterval(myInterval);
-												bf_add_yearscroller(fieldname);
-											}
-										}, 200);
-									}
-								}
-								//-->
-							</script>
-							<?php
-							$c = ob_get_contents();
-							ob_end_clean();
+							Factory::getApplication()->getDocument()->getWebAssetManager()->addInlineScript(
+								'var bfPickerMinusYearIcon = ' . json_encode(Uri::root(true) . '/components/com_breezingformsng/libraries/jquery/pickadate/minusyear.png') . ';'
+								. "\n" . 'var bfPickerPlusYearIcon = ' . json_encode(Uri::root(true) . '/components/com_breezingformsng/libraries/jquery/pickadate/plusyear.png') . ';'
+							);
+							Factory::getApplication()->getDocument()->addScript(Uri::root(true) . '/media/com_breezingformsng/js/site/quickmode-calendar-responsive.js');
 						}
-
-						echo $c;
 
 	                        echo '<script type="text/javascript">
 	                                                <!--

--- a/components/com_breezingformsng/src/Service/Rendering/QuickMode/ClassicRenderer.php
+++ b/components/com_breezingformsng/src/Service/Rendering/QuickMode/ClassicRenderer.php
@@ -1710,73 +1710,7 @@ display:none;
 			Factory::getApplication()->getSession()->set('bfFlashUploadTickets', $tickets);
 			echo '<input type="hidden" name="bfFlashUploadTicket" value="' . $this->flashUploadTicket . '"/>' . "\n";
 			Factory::getApplication()->getDocument()->addScript(Uri::root(true) . '/components/com_breezingformsng/libraries/jquery/center.js');
-			Factory::getApplication()->getDocument()->getWebAssetManager()->addInlineScript('
-                        var bfUploaders = [];
-                        var bfUploaderErrorElements = [];
-			var bfFlashUploadInterval = null;
-			var bfFlashUploaders = new Array();
-                        var bfFlashUploadersLength = 0;
-                        function bfRefreshAll(){
-                            for( var i = 0; i < bfUploaders.length; i++ ){
-                                bfUploaders[i].refresh();
-                            }
-                        }
-                        function bfInitAll(){
-                            for( var i = 0; i < bfUploaders.length; i++ ){
-                                bfUploaders[i].init();
-                            }
-                        }
-			function bfDoFlashUpload(){
-                                JQuery("#bfSubmitMessage").css("visibility","hidden");
-                                JQuery("#bfSubmitMessage").css("display","none");
-                                JQuery("#bfSubmitMessage").css("z-index","999999");
-				JQuery(".bfErrorMessage").html("");
-                                JQuery(".bfErrorMessage").css("display","none");
-                                for(var i = 0; i < bfUploaderErrorElements.length; i++){
-                                    JQuery("#"+bfUploaderErrorElements[i]).html("");
-                                }
-                                bfUploaderErrorElements = [];
-                                if(ff_validation(0) == ""){
-					try{
-                                            bfFlashUploadInterval = window.setInterval( bfCheckFlashUploadProgress, 1000 );
-                                            if(bfFlashUploadersLength > 0){
-                                                JQuery("#bfFileQueue").bfcenter(true);
-                                                JQuery("#bfFileQueue").css("visibility","visible");
-                                                for( var i = 0; i < bfUploaders.length; i++ ){
-                                                    bfUploaders[i].start();
-                                                }
-                                            }
-					} catch(e){alert(e)}
-				} else {
-					if(typeof bfUseErrorAlerts == "undefined"){
-                                            alert(error);
-                                        } else {
-                                            bfShowErrors(error);
-                                        }
-                                        ff_validationFocus("");
-                                        document.getElementById("bfSubmitButton").disabled = false;
-				}
-			}
-			function bfCheckFlashUploadProgress(){
-                                if( JQuery("#bfFileQueue").html() == "" ){ // empty indicates that all queues are uploaded or in any way cancelled
-					JQuery("#bfFileQueue").css("visibility","hidden");
-					window.clearInterval( bfFlashUploadInterval );
-                                        if(typeof bfAjaxObject101 != \'undefined\' || typeof bfReCaptchaLoaded != \'undefined\'){
-                                            ff_submitForm2();
-                                        }else{
-                                            ff_validate_submit(document.getElementById("bfSubmitButton"), "click");
-                                        }
-					JQuery(".bfFlashFileQueueClass").html("");
-                                        if(bfFlashUploadersLength > 0){
-                                            JQuery("#bfSubmitMessage").bfcenter(true);
-                                            JQuery("#bfSubmitMessage").css("visibility","visible");
-                                            JQuery("#bfSubmitMessage").css("display","block");
-                                            JQuery("#bfSubmitMessage").css("z-index","999999");
-                                        }
-
-				}
-			}
-			');
+			Factory::getApplication()->getDocument()->addScript(Uri::root(true) . '/media/com_breezingformsng/js/site/quickmode-flash-upload.js');
 			echo "<div style=\"visibility:hidden;\" id=\"bfFileQueue\"></div>";
 			echo "<div style=\"visibility:hidden;display:none;\" id=\"bfSubmitMessage\">" . Text::_('COM_BREEZINGFORMSNG_SUBMIT_MESSAGE') . "</div>";
 		}

--- a/components/com_breezingformsng/src/Service/Rendering/QuickMode/ClassicRenderer.php
+++ b/components/com_breezingformsng/src/Service/Rendering/QuickMode/ClassicRenderer.php
@@ -1363,68 +1363,14 @@ display:none;
 
 					case 'bfSignature':
 
-						$base = 'ba'.'se'.'64';
-
 						Factory::getApplication()->getDocument()->addScript(Uri::root(true).'/components/com_breezingformsng/libraries/js/signature.js');
-						Factory::getApplication()->getDocument()->getWebAssetManager()->addInlineScript('
-						var bf_signaturePad' . $mdata['dbId'] . ' = null;
-						var bf_canvas' . $mdata['dbId'] . ' = null;
-
-						function bf_resizeCanvas' . $mdata['dbId'] . 'Func() {
-
-							if(arguments[0] !== false){
-
-								var data = bf_signaturePad' . $mdata['dbId'] . '.toDataURL();
-
-							}
-
-						    var ratio =  Math.max(window.devicePixelRatio || 1, 1);
-						    bf_canvas' . $mdata['dbId'] . '.width = bf_canvas' . $mdata['dbId'] . '.offsetWidth * ratio;
-						    bf_canvas' . $mdata['dbId'] . '.height = bf_canvas' . $mdata['dbId'] . '.offsetHeight * ratio;
-						    bf_canvas' . $mdata['dbId'] . '.getContext("2d").scale(ratio, ratio);
-
-						    if(arguments[0] !== false){
-
-						        bf_signaturePad' . $mdata['dbId'] . '.fromDataURL(data);
-						        JQuery("#ff_elem' . $mdata['dbId'] . '").val(data.replace("data:image/png;'.$base.',",""));
-						    }
-
-						    bf_signaturePad' . $mdata['dbId'] . ' = new SignaturePad(bf_canvas' . $mdata['dbId'] . ', {
-							    backgroundColor: "rgb(255,255,255)",
-							    penColor: "rgb(0,0,0)",
-							    onEnd: function(){
-							        var data = bf_signaturePad' . $mdata['dbId'] . '.toDataURL();
-							        JQuery("#ff_elem' . $mdata['dbId'] . '").val(data.replace("data:image/png;'.$base.',",""));
-							    }
-							});
-						}
-
-						function bf_Signature' . $mdata['dbId'] . 'Reset(sig) {
-							sig.clear();
-							JQuery("#ff_elem' . $mdata['dbId'] . '").val("");
-						}
-
-						JQuery(document).ready(function(){
-							bf_canvas' . $mdata['dbId'] . ' = document.querySelector("#bfSignature' . $mdata['dbId'] . ' canvas");
-                            if(bf_canvas' . $mdata['dbId'] . ' == null) return;
-
-							// trouble on mobile devices, thinks swiping is resize...
-							JQuery(window).on("resize", bf_resizeCanvas' . $mdata['dbId'] . 'Func);
-
-							bf_resizeCanvas' . $mdata['dbId'] . 'Func(false);
-
-							// make sure the canvas is resized if dimensions are zero
-							setInterval(function(){
-								if( bf_canvas' . $mdata['dbId'] . '.width == 0 && bf_canvas' . $mdata['dbId'] . '.height == 0 ){
-									bf_resizeCanvas' . $mdata['dbId'] . 'Func(false);
-								}
-							}, 500);
-
-						});
-						');
+						Factory::getApplication()->getDocument()->addScript(Uri::root(true).'/media/com_breezingformsng/js/site/quickmode-signature.js');
+						Factory::getApplication()->getDocument()->getWebAssetManager()->addInlineScript(
+							'bfSignatureInit(' . json_encode((int) $mdata['dbId']) . ');'
+						);
 
 						echo '<div class="bfSignature" id="bfSignature' . $mdata['dbId'] . '"><div class="bfSignatureCanvasBorder"><canvas></canvas></div>'."\n";
-						echo '<button class="btn btn-primary" onclick="bf_Signature' . $mdata['dbId'] . 'Reset(bf_signaturePad' . $mdata['dbId'] . ');" class="bfSignatureResetButton button"><span>'.Text::_('COM_BREEZINGFORMSNG_SIGNATURE_RESET_BUTTON').'</span></button>'."\n";
+						echo '<button class="btn btn-primary" onclick="bfSignatureReset(' . json_encode((int) $mdata['dbId']) . ');" class="bfSignatureResetButton button"><span>'.Text::_('COM_BREEZINGFORMSNG_SIGNATURE_RESET_BUTTON').'</span></button>'."\n";
 						echo '<span class=\'bfSignature' . $mdata['bfName'] . '\'></span>';
 						echo '</div>';
 						echo '<input class="ff_elem" type="hidden" name="ff_nm_' . $mdata['bfName'] . '[]" value="" id="ff_elem' . $mdata['dbId'] . '"/>' . "\n";

--- a/components/com_breezingformsng/src/Service/Rendering/QuickMode/MobileRenderer.php
+++ b/components/com_breezingformsng/src/Service/Rendering/QuickMode/MobileRenderer.php
@@ -1495,67 +1495,14 @@ var toggleFieldsArray = ' . $this->toggleFields . ';
 
 					case 'bfSignature':
 
-						$base = 'ba' . 'se' . '64';
-
 						$this->addScript(Uri::root(true) . '/components/com_breezingformsng/libraries/js/signature.js');
-						$this->addScriptDeclaration('
-						var bf_signaturePad' . $mdata['dbId'] . ' = null;
-						var bf_canvas' . $mdata['dbId'] . ' = null;
-
-						function bf_resizeCanvas' . $mdata['dbId'] . 'Func() {
-
-							if(arguments[0] !== false){
-
-								var data = bf_signaturePad' . $mdata['dbId'] . '.toDataURL();
-
-							}
-
-						    var ratio =  Math.max(window.devicePixelRatio || 1, 1);
-						    bf_canvas' . $mdata['dbId'] . '.width = bf_canvas' . $mdata['dbId'] . '.offsetWidth * ratio;
-						    bf_canvas' . $mdata['dbId'] . '.height = bf_canvas' . $mdata['dbId'] . '.offsetHeight * ratio;
-						    bf_canvas' . $mdata['dbId'] . '.getContext("2d").scale(ratio, ratio);
-
-						    if(arguments[0] !== false){
-
-						        bf_signaturePad' . $mdata['dbId'] . '.fromDataURL(data);
-						        JQuery("#ff_elem' . $mdata['dbId'] . '").val(data.replace("data:image/png;' . $base . ',",""));
-						    }
-
-						    bf_signaturePad' . $mdata['dbId'] . ' = new SignaturePad(bf_canvas' . $mdata['dbId'] . ', {
-							    backgroundColor: "rgb(255,255,255)",
-							    penColor: "rgb(0,0,0)",
-							    onEnd: function(){
-							        var data = bf_signaturePad' . $mdata['dbId'] . '.toDataURL();
-							        JQuery("#ff_elem' . $mdata['dbId'] . '").val(data.replace("data:image/png;' . $base . ',",""));
-							    }
-							});
-						}
-
-						function bf_Signature' . $mdata['dbId'] . 'Reset(sig) {
-							sig.clear();
-							JQuery("#ff_elem' . $mdata['dbId'] . '").val("");
-						}
-
-						JQuery(document).ready(function(){
-							bf_canvas' . $mdata['dbId'] . ' = document.querySelector("#bfSignature' . $mdata['dbId'] . ' canvas");
-
-							// causes trouble as swipes will falsely triggered as resize events
-							JQuery(window).on("resize", bf_resizeCanvas' . $mdata['dbId'] . 'Func);
-
-							bf_resizeCanvas' . $mdata['dbId'] . 'Func(false);
-
-							// make sure the canvas is resized if dimensions are zero
-							setInterval(function(){
-								if( bf_canvas' . $mdata['dbId'] . '.width == 0 && bf_canvas' . $mdata['dbId'] . '.height == 0 ){
-									bf_resizeCanvas' . $mdata['dbId'] . 'Func(false);
-								}
-							}, 500);
-
-						});
-						');
+						$this->addScript(Uri::root(true) . '/media/com_breezingformsng/js/site/quickmode-signature.js');
+						$this->addScriptDeclaration(
+							'bfSignatureInit(' . json_encode((int) $mdata['dbId']) . ');'
+						);
 
 						echo '<div class="bfSignature" id="bfSignature' . $mdata['dbId'] . '"><div class="bfSignatureCanvasBorder"><canvas></canvas></div>' . "\n";
-						echo '<button onclick="bf_Signature' . $mdata['dbId'] . 'Reset(bf_signaturePad' . $mdata['dbId'] . ');" class="bfSignatureResetButton button btn btn-primary"><span>' . Text::_('COM_BREEZINGFORMSNG_SIGNATURE_RESET_BUTTON') . '</span></button>' . "\n";
+						echo '<button onclick="bfSignatureReset(' . json_encode((int) $mdata['dbId']) . ');" class="bfSignatureResetButton button btn btn-primary"><span>' . Text::_('COM_BREEZINGFORMSNG_SIGNATURE_RESET_BUTTON') . '</span></button>' . "\n";
 						echo '</div>';
 						echo '<input class="ff_elem" type="hidden" name="ff_nm_' . $mdata['bfName'] . '[]" value="" id="ff_elem' . $mdata['dbId'] . '"/>' . "\n";
 

--- a/components/com_breezingformsng/src/Service/Rendering/QuickMode/MobileRenderer.php
+++ b/components/com_breezingformsng/src/Service/Rendering/QuickMode/MobileRenderer.php
@@ -337,71 +337,7 @@ JS;
 			$tickets[$this->flashUploadTicket] = array(); // stores file info for later processing
 			Factory::getApplication()->getSession()->set('bfFlashUploadTickets', $tickets);
 			$this->addScript(Uri::root(true) . '/components/com_breezingformsng/libraries/jquery/center.js');
-			$this->addScriptDeclaration('
-                        var bfUploaders = [];
-                        var bfUploaderErrorElements = [];
-			var bfFlashUploadInterval = null;
-			var bfFlashUploaders = new Array();
-                        var bfFlashUploadersLength = 0;
-                        function bfRefreshAll(){
-                            for( var i = 0; i < bfUploaders.length; i++ ){
-                                bfUploaders[i].refresh();
-                            }
-                        }
-                        function bfInitAll(){
-                            for( var i = 0; i < bfUploaders.length; i++ ){
-                                bfUploaders[i].init();
-                            }
-                        }
-			function bfDoFlashUpload(){
-                                JQuery("#bfSubmitMessage").css("visibility","hidden");
-                                JQuery("#bfSubmitMessage").css("z-index","999999");
-				JQuery(".bfErrorMessage").html("");
-                                JQuery(".bfErrorMessage").css("display","none");
-                                for(var i = 0; i < bfUploaderErrorElements.length; i++){
-                                    JQuery("#"+bfUploaderErrorElements[i]).html("");
-                                }
-                                bfUploaderErrorElements = [];
-                                if(ff_validation(0) == ""){
-					try{
-                                            bfFlashUploadInterval = window.setInterval( bfCheckFlashUploadProgress, 1000 );
-                                            if(bfFlashUploadersLength > 0){
-                                                JQuery("#bfFileQueue").bfcenter(true);
-                                                JQuery("#bfFileQueue").css("visibility","visible");
-                                                for( var i = 0; i < bfUploaders.length; i++ ){
-                                                    bfUploaders[i].start();
-                                                }
-                                            }
-					} catch(e){alert(e)}
-				} else {
-					if(typeof bfUseErrorAlerts == "undefined"){
-                                            alert(error);
-                                        } else {
-                                            bfShowErrors(error);
-                                        }
-                                        ff_validationFocus("");
-                                        document.getElementById("bfSubmitButton").disabled = false;
-				}
-			}
-			function bfCheckFlashUploadProgress(){
-				if( JQuery("#bfFileQueue").html() == "" ){ // empty indicates that all queues are uploaded or in any way cancelled
-					JQuery("#bfFileQueue").css("visibility","hidden");
-					window.clearInterval( bfFlashUploadInterval );
-                                        if(typeof bfAjaxObject101 != \'undefined\' || typeof bfReCaptchaLoaded != \'undefined\'){
-                                            ff_submitForm2();
-                                        }else{
-                                            ff_validate_submit(document.getElementById("bfSubmitButton"), "click");
-                                        }
-					JQuery(".bfFlashFileQueueClass").html("");
-                                        if(bfFlashUploadersLength > 0){
-                                            JQuery("#bfSubmitMessage").bfcenter(true);
-                                            JQuery("#bfSubmitMessage").css("visibility","visible");
-                                            JQuery("#bfSubmitMessage").css("z-index","999999");
-                                        }
-
-				}
-			}
-			');
+			$this->addScript(Uri::root(true) . '/media/com_breezingformsng/js/site/quickmode-flash-upload-mobile.js');
 		}
 
 		if ($this->useBalloonErrors) {

--- a/components/com_breezingformsng/src/Service/Rendering/QuickMode/OnePageRenderer.php
+++ b/components/com_breezingformsng/src/Service/Rendering/QuickMode/OnePageRenderer.php
@@ -2215,19 +2215,7 @@ var toggleFieldsArray = ' . $this->toggleFields . ';
             echo "<div style=\"visibility:hidden;display:none;\" id=\"bfSubmitMessage\">" . Text::_('COM_BREEZINGFORMSNG_SUBMIT_MESSAGE') . "</div>";
         }
         echo '<noscript>Please turn on javascript to submit your data. Thank you!</noscript>' . "\n";
-        echo '<script type="text/javascript">
-                <!--
-                function ff_switchpage(page){
-                    for( var i = page; i > 0; i-- ){
-                        JQuery("#bfPage"+i).css("pointer-events","auto");
-                        JQuery("#bfPage"+i).css("opacity","1.0");
-                    }
-                    ff_currentpage = page;
-                    ff_initialize("pageentry");
-                    JQuery("#bfPage"+page).ScrollTo({offsetTop: 50});
-                }
-                //-->
-                </script>';
+        Factory::getApplication()->getDocument()->addScript(Uri::root(true) . '/media/com_breezingformsng/js/site/quickmode-onepage-switchpage.js');
         if ($this->rootMdata['lastPageThankYou']) {
             echo '
                         <div class="remodal" data-remodal-id="modal">

--- a/components/com_breezingformsng/src/Service/Rendering/QuickMode/OnePageRenderer.php
+++ b/components/com_breezingformsng/src/Service/Rendering/QuickMode/OnePageRenderer.php
@@ -1803,56 +1803,13 @@ var toggleFieldsArray = ' . $this->toggleFields . ';
 
                         $container = 'JQuery("body").append("<div class=\"bfCalendarResponsiveContainer' . $mdata['dbId'] . '\" style=\"display:block;position:absolute;left:-9999px;\"></div>");';
 
-                        $c = '';
-
                         if (!$this->hasResponsiveDatePicker) {
-                            ob_start();
-                            ?>
-                                    <script type="text/javascript">
-                                                                                                                        <!--
-                                                                                                            function bf_add_yearscroller(fieldname) {
-                                                                                                                            if (!JQuery("#bfCalExt" + fieldname).length) {
-                                                                                                                                // prev
-                                                                                                                                if (JQuery(".bfCalendarResponsiveContainer" + fieldname + " .picker__select--year").get(0).selectedIndex > 0) {
-                                                                                                                                    JQuery(".bfCalendarResponsiveContainer" + fieldname + " .picker__select--year").before('<img id="bfCalExt' + fieldname + '" onclick="JQuery(\'.bfCalendarResponsiveContainer' + fieldname + ' .picker__select--year\').get(0).selectedIndex=JQuery(\'.bfCalendarResponsiveContainer' + fieldname + ' .picker__select--year\').get(0).selectedIndex-1;JQuery(\'.bfCalendarResponsiveContainer' + fieldname + ' .picker__select--year\').trigger(\'change\')" border="0" src="<?php echo Uri::root(true) . '/components/com_breezingformsng/libraries/jquery/pickadate/minusyear.png' ?>" style="width: 30px; vertical - align: top; cursor: pointer; " />');
-                                                                                                                                }
-                                        // next
-                                        if (JQuery(".bfCalendarResponsiveContainer" + fieldname + " .picker__select--year").get(0).selectedIndex + 1 < JQuery(".bfCalendarResponsiveContainer" + fieldname + " .picker__select--year").get(0).options.length) {
-                                            JQuery(".bfCalendarResponsiveContainer" + fieldname + " .picker__select--year").after('<img id="bfCalExt' + fieldname + '" onclick="JQuery(\'.bfCalendarResponsiveContainer' + fieldname + ' .picker__select--year\').get(0).selectedIndex=JQuery(\'.bfCalendarResponsiveContainer' + fieldname + ' .picker__select--year\').get(0).selectedIndex+1;JQuery(\'.bfCalendarResponsiveContainer' + fieldname + ' .picker__select--year\').trigger(\'change\')" border="0" src="<?php echo Uri::root(true) . '/components/com_breezingformsng/libraries/jquery/pickadate/plusyear.png' ?>" style="width: 30px; vertical-align: top; cursor:pointer;" />');
-                                        }
-
-                                        JQuery('.bfCalendarResponsiveContainer' + fieldname + ' .picker__select--year').on('change', function () {
-                                            bf_add_yearscroller(fieldname);
-                                        });
-                                        JQuery('.bfCalendarResponsiveContainer' + fieldname + ' .picker__select--month').on('change', function () {
-                                            bf_add_yearscroller(fieldname);
-                                        });
-
-                                        var myVal = JQuery('.bfCalendarResponsiveContainer' + fieldname + ' .picker__select--year').val();
-                                        var myInterval = setInterval(function () {
-                                            if (myVal != JQuery('.bfCalendarResponsiveContainer' + fieldname + ' .picker__select--year').val()) {
-                                                clearInterval(myInterval);
-                                                bf_add_yearscroller(fieldname);
-                                            }
-                                        }, 200);
-
-                                        var myVal = JQuery('.bfCalendarResponsiveContainer' + fieldname + ' .picker__select--month').val();
-                                        var myInterval = setInterval(function () {
-                                            if (myVal != JQuery('.bfCalendarResponsiveContainer' + fieldname + ' .picker__select--month').val()) {
-                                                clearInterval(myInterval);
-                                                bf_add_yearscroller(fieldname);
-                                            }
-                                        }, 200);
-                                                                                                                            }
-                                                                                                                        }
-                                        //-->
-                                    </script>
-                                <?php
-                                $c = ob_get_contents();
-                                ob_end_clean();
+                            Factory::getApplication()->getDocument()->getWebAssetManager()->addInlineScript(
+                                'var bfPickerMinusYearIcon = ' . json_encode(Uri::root(true) . '/components/com_breezingformsng/libraries/jquery/pickadate/minusyear.png') . ';'
+                                . "\n" . 'var bfPickerPlusYearIcon = ' . json_encode(Uri::root(true) . '/components/com_breezingformsng/libraries/jquery/pickadate/plusyear.png') . ';'
+                            );
+                            Factory::getApplication()->getDocument()->addScript(Uri::root(true) . '/media/com_breezingformsng/js/site/quickmode-calendar-responsive-legacy-style.js');
                         }
-
-                        echo $c;
 
                         echo '<script type="text/javascript">
                                                 <!--

--- a/components/com_breezingformsng/src/Service/Rendering/QuickMode/OnePageRenderer.php
+++ b/components/com_breezingformsng/src/Service/Rendering/QuickMode/OnePageRenderer.php
@@ -2253,74 +2253,7 @@ var toggleFieldsArray = ' . $this->toggleFields . ';
 	    Factory::getApplication()->getSession()->set('bfFlashUploadTickets', $tickets);
             echo '<input type="hidden" name="bfFlashUploadTicket" value="' . $this->flashUploadTicket . '"/>' . "\n";
             Factory::getApplication()->getDocument()->addScript(Uri::root(true) . '/components/com_breezingformsng/libraries/jquery/center.js');
-            Factory::getApplication()->getDocument()->getWebAssetManager()->addInlineScript('
-                        var bfUploaders = [];
-                        var bfUploaderErrorElements = [];
-			var bfFlashUploadInterval = null;
-			var bfFlashUploaders = new Array();
-                        var bfFlashUploadersLength = 0;
-                        function bfRefreshAll(){
-                            for( var i = 0; i < bfUploaders.length; i++ ){
-                                bfUploaders[i].refresh();
-                            }
-                        }
-                        function bfInitAll(){
-                            for( var i = 0; i < bfUploaders.length; i++ ){
-                                bfUploaders[i].init();
-                            }
-                        }
-			function bfDoFlashUpload(){
-                                JQuery("#bfSubmitMessage").css("visibility","hidden");
-                                JQuery("#bfSubmitMessage").css("display","none");
-                                JQuery("#bfSubmitMessage").css("z-index","999999");
-				JQuery(".bfErrorMessage").html("");
-                                JQuery(".bfErrorMessage").css("display","none");
-                                for(var i = 0; i < bfUploaderErrorElements.length; i++){
-                                    JQuery("#"+bfUploaderErrorElements[i]).html("");
-                                }
-                                bfUploaderErrorElements = [];
-                                if(ff_validation(0) == ""){
-					try{
-                                            bfFlashUploadInterval = window.setInterval( bfCheckFlashUploadProgress, 1000 );
-                                            if(bfFlashUploadersLength > 0){
-                                                JQuery("#bfFileQueue").bfcenter(true);
-                                                JQuery("#bfFileQueue").css("visibility","visible");
-                                                for( var i = 0; i < bfUploaders.length; i++ ){
-                                                    bfUploaders[i].start();
-                                                }
-                                            }
-					} catch(e){alert(e)}
-				} else {
-					if(typeof bfUseErrorAlerts == "undefined"){
-                                            alert(error);
-                                        } else {
-                                            alert(error);
-                                        }
-                                        ff_validationFocus("");
-                                        document.getElementById("bfSubmitButton").disabled = false;
-                                        ladda_button.ladda("stop");
-				}
-			}
-			function bfCheckFlashUploadProgress(){
-                                if( JQuery("#bfFileQueue").html() == "" ){ // empty indicates that all queues are uploaded or in any way cancelled
-					JQuery("#bfFileQueue").css("visibility","hidden");
-					window.clearInterval( bfFlashUploadInterval );
-                                        if(typeof bfAjaxObject101 != \'undefined\' || typeof bfReCaptchaLoaded != \'undefined\'){
-                                            ff_submitForm2();
-                                        }else{
-                                            bf_validate_submit(document.getElementById("bfSubmitButton"), "click");
-                                        }
-					JQuery(".bfFlashFileQueueClass").html("");
-                                        if(bfFlashUploadersLength > 0){
-                                            JQuery("#bfSubmitMessage").bfcenter(true);
-                                            JQuery("#bfSubmitMessage").css("visibility","visible");
-                                            JQuery("#bfSubmitMessage").css("display","block");
-                                            JQuery("#bfSubmitMessage").css("z-index","999999");
-                                        }
-
-				}
-			}
-			');
+            Factory::getApplication()->getDocument()->addScript(Uri::root(true) . '/media/com_breezingformsng/js/site/quickmode-flash-upload-onepage.js');
             echo "<div style=\"visibility:hidden;\" id=\"bfFileQueue\"></div>";
             echo "<div style=\"visibility:hidden;display:none;\" id=\"bfSubmitMessage\">" . Text::_('COM_BREEZINGFORMSNG_SUBMIT_MESSAGE') . "</div>";
         }

--- a/components/com_breezingformsng/src/Service/Rendering/QuickMode/OnePageRenderer.php
+++ b/components/com_breezingformsng/src/Service/Rendering/QuickMode/OnePageRenderer.php
@@ -1847,65 +1847,11 @@ var toggleFieldsArray = ' . $this->toggleFields . ';
 
                     case 'bfSignature':
 
-                        $base = 'ba' . 'se' . '64';
-
                         Factory::getApplication()->getDocument()->addScript(Uri::root(true) . '/components/com_breezingformsng/libraries/js/signature.js');
-                        Factory::getApplication()->getDocument()->getWebAssetManager()->addInlineScript('
-						var bf_signaturePad' . $mdata['dbId'] . ' = null;
-						var bf_canvas' . $mdata['dbId'] . ' = null;
-
-						function bf_resizeCanvas' . $mdata['dbId'] . 'Func() {
-
-							if(arguments[0] !== false){
-
-								var data = bf_signaturePad' . $mdata['dbId'] . '.toDataURL();
-
-							}
-
-						    var ratio =  Math.max(window.devicePixelRatio || 1, 1);
-						    bf_canvas' . $mdata['dbId'] . '.width = bf_canvas' . $mdata['dbId'] . '.offsetWidth * ratio;
-						    bf_canvas' . $mdata['dbId'] . '.height = bf_canvas' . $mdata['dbId'] . '.offsetHeight * ratio;
-						    bf_canvas' . $mdata['dbId'] . '.getContext("2d").scale(ratio, ratio);
-
-						    if(arguments[0] !== false){
-
-						        bf_signaturePad' . $mdata['dbId'] . '.fromDataURL(data);
-						        JQuery("#ff_elem' . $mdata['dbId'] . '").val(data.replace("data:image/png;' . $base . ',",""));
-						    }
-
-						    bf_signaturePad' . $mdata['dbId'] . ' = new SignaturePad(bf_canvas' . $mdata['dbId'] . ', {
-							    backgroundColor: "rgb(255,255,255)",
-							    penColor: "rgb(0,0,0)",
-							    onEnd: function(){
-							        var data = bf_signaturePad' . $mdata['dbId'] . '.toDataURL();
-							        JQuery("#ff_elem' . $mdata['dbId'] . '").val(data.replace("data:image/png;' . $base . ',",""));
-							    }
-							});
-						}
-
-						function bf_Signature' . $mdata['dbId'] . 'Reset(sig) {
-							sig.clear();
-							JQuery("#ff_elem' . $mdata['dbId'] . '").val("");
-						}
-
-						JQuery(document).ready(function(){
-							bf_canvas' . $mdata['dbId'] . ' = document.querySelector("#bfSignature' . $mdata['dbId'] . ' canvas");
-                            if(bf_canvas' . $mdata['dbId'] . ' == null) return;
-                            
-							// trouble on mobile devices, thinks swiping is resize...
-							JQuery(window).on("resize", bf_resizeCanvas' . $mdata['dbId'] . 'Func);
-
-							bf_resizeCanvas' . $mdata['dbId'] . 'Func(false);
-
-							// make sure the canvas is resized if dimensions are zero
-							setInterval(function(){
-								if( bf_canvas' . $mdata['dbId'] . '.width == 0 && bf_canvas' . $mdata['dbId'] . '.height == 0 ){
-									bf_resizeCanvas' . $mdata['dbId'] . 'Func(false);
-								}
-							}, 500);
-
-						});
-						');
+                        Factory::getApplication()->getDocument()->addScript(Uri::root(true) . '/media/com_breezingformsng/js/site/quickmode-signature.js');
+                        Factory::getApplication()->getDocument()->getWebAssetManager()->addInlineScript(
+                            'bfSignatureInit(' . json_encode((int) $mdata['dbId']) . ');'
+                        );
 
                         echo '<div class="' . $this->bsClass('controls') . ' ' . $this->bsClass('form-inline') . ' bfSignatureWrap">';
                         echo '<div class="' . $this->bsClass('form-group') . ' ' . $this->bsClass('other-form-group') . '">';
@@ -1913,7 +1859,7 @@ var toggleFieldsArray = ' . $this->toggleFields . ';
                         echo '<span class="' . $this->bsClass('nonform-control') . '">';
 
                         echo '<div class="bfSignature" id="bfSignature' . $mdata['dbId'] . '"><div class="bfSignatureCanvasBorder"><canvas></canvas></div>' . "\n";
-                        echo '<button onclick="bf_Signature' . $mdata['dbId'] . 'Reset(bf_signaturePad' . $mdata['dbId'] . ');" class="bfSignatureResetButton button ' . $this->bsClass('btn') . ' ' . $this->bsClass('btn-primary') . '"><span>' . Text::_('COM_BREEZINGFORMSNG_SIGNATURE_RESET_BUTTON') . '</span></button>' . "\n";
+                        echo '<button onclick="bfSignatureReset(' . json_encode((int) $mdata['dbId']) . ');" class="bfSignatureResetButton button ' . $this->bsClass('btn') . ' ' . $this->bsClass('btn-primary') . '"><span>' . Text::_('COM_BREEZINGFORMSNG_SIGNATURE_RESET_BUTTON') . '</span></button>' . "\n";
                         echo '</div>';
 
                         echo '</span>';

--- a/media/com_breezingformsng/js/site/quickmode-calendar-responsive-legacy-style.js
+++ b/media/com_breezingformsng/js/site/quickmode-calendar-responsive-legacy-style.js
@@ -1,0 +1,47 @@
+/* Extracted from BFQuickModeBootstrap's and BFQuickModeOnePage's inline
+   process() scripts (Phase 9c step 2b) - the year/month scroller buttons
+   added next to a responsive calendar picker's year/month dropdowns.
+   Only loaded once per page, the first time a bfCalendarResponsive
+   element is rendered. Kept separate from the classic theme's
+   quickmode-calendar-responsive.js: the "prev year" icon's inline style
+   has a pre-existing typo ("vertical - align" with stray spaces,
+   silently ignored as invalid CSS by the browser) that only exists in
+   these two themes - preserved as-is rather than "fixed" during this
+   relocation. Depends on two globals declared inline right before this
+   file is loaded: bfPickerMinusYearIcon and bfPickerPlusYearIcon (the
+   prev/next icon URLs). */
+function bf_add_yearscroller(fieldname) {
+if (!JQuery("#bfCalExt" + fieldname).length) {
+// prev
+if (JQuery(".bfCalendarResponsiveContainer" + fieldname + " .picker__select--year").get(0).selectedIndex > 0) {
+JQuery(".bfCalendarResponsiveContainer" + fieldname + " .picker__select--year").before('<img id="bfCalExt' + fieldname + '" onclick="JQuery(\'.bfCalendarResponsiveContainer' + fieldname + ' .picker__select--year\').get(0).selectedIndex=JQuery(\'.bfCalendarResponsiveContainer' + fieldname + ' .picker__select--year\').get(0).selectedIndex-1;JQuery(\'.bfCalendarResponsiveContainer' + fieldname + ' .picker__select--year\').trigger(\'change\')" border="0" src="' + bfPickerMinusYearIcon + '" style="width: 30px; vertical - align: top; cursor: pointer; " />');
+}
+// next
+if (JQuery(".bfCalendarResponsiveContainer" + fieldname + " .picker__select--year").get(0).selectedIndex + 1 < JQuery(".bfCalendarResponsiveContainer" + fieldname + " .picker__select--year").get(0).options.length) {
+JQuery(".bfCalendarResponsiveContainer" + fieldname + " .picker__select--year").after('<img id="bfCalExt' + fieldname + '" onclick="JQuery(\'.bfCalendarResponsiveContainer' + fieldname + ' .picker__select--year\').get(0).selectedIndex=JQuery(\'.bfCalendarResponsiveContainer' + fieldname + ' .picker__select--year\').get(0).selectedIndex+1;JQuery(\'.bfCalendarResponsiveContainer' + fieldname + ' .picker__select--year\').trigger(\'change\')" border="0" src="' + bfPickerPlusYearIcon + '" style="width: 30px; vertical-align: top; cursor:pointer;" />');
+}
+
+JQuery('.bfCalendarResponsiveContainer' + fieldname + ' .picker__select--year').on('change', function () {
+bf_add_yearscroller(fieldname);
+});
+JQuery('.bfCalendarResponsiveContainer' + fieldname + ' .picker__select--month').on('change', function () {
+bf_add_yearscroller(fieldname);
+});
+
+var myVal = JQuery('.bfCalendarResponsiveContainer' + fieldname + ' .picker__select--year').val();
+var myInterval = setInterval(function () {
+if (myVal != JQuery('.bfCalendarResponsiveContainer' + fieldname + ' .picker__select--year').val()) {
+clearInterval(myInterval);
+bf_add_yearscroller(fieldname);
+}
+}, 200);
+
+var myVal = JQuery('.bfCalendarResponsiveContainer' + fieldname + ' .picker__select--month').val();
+var myInterval = setInterval(function () {
+if (myVal != JQuery('.bfCalendarResponsiveContainer' + fieldname + ' .picker__select--month').val()) {
+clearInterval(myInterval);
+bf_add_yearscroller(fieldname);
+}
+}, 200);
+}
+}

--- a/media/com_breezingformsng/js/site/quickmode-calendar-responsive.js
+++ b/media/com_breezingformsng/js/site/quickmode-calendar-responsive.js
@@ -1,0 +1,43 @@
+/* Extracted from BFQuickMode's inline process() script (Phase 9c step 2b)
+   - the year/month scroller buttons added next to a responsive calendar
+   picker's year/month dropdowns. Only loaded once per page, the first
+   time a bfCalendarResponsive element is rendered (see
+   ClassicRenderer::hasResponsiveDatePicker). Depends on two globals
+   declared inline right before this file is loaded: bfPickerMinusYearIcon
+   and bfPickerPlusYearIcon (the prev/next icon URLs, which depend on the
+   site's base path so can't be hardcoded here). */
+function bf_add_yearscroller(fieldname) {
+		if (!JQuery("#bfCalExt" + fieldname).length) {
+			// prev
+			if (JQuery(".bfCalendarResponsiveContainer" + fieldname + " .picker__select--year").get(0).selectedIndex > 0) {
+				JQuery(".bfCalendarResponsiveContainer" + fieldname + " .picker__select--year").before('<img id="bfCalExt' + fieldname + '" onclick="JQuery(\'.bfCalendarResponsiveContainer' + fieldname + ' .picker__select--year\').get(0).selectedIndex=JQuery(\'.bfCalendarResponsiveContainer' + fieldname + ' .picker__select--year\').get(0).selectedIndex-1;JQuery(\'.bfCalendarResponsiveContainer' + fieldname + ' .picker__select--year\').trigger(\'change\')" border="0" src="' + bfPickerMinusYearIcon + '" style="width: 30px; vertical-align: top; cursor:pointer;" />');
+			}
+			// next
+			if (JQuery(".bfCalendarResponsiveContainer" + fieldname + " .picker__select--year").get(0).selectedIndex + 1 < JQuery(".bfCalendarResponsiveContainer" + fieldname + " .picker__select--year").get(0).options.length) {
+				JQuery(".bfCalendarResponsiveContainer" + fieldname + " .picker__select--year").after('<img id="bfCalExt' + fieldname + '" onclick="JQuery(\'.bfCalendarResponsiveContainer' + fieldname + ' .picker__select--year\').get(0).selectedIndex=JQuery(\'.bfCalendarResponsiveContainer' + fieldname + ' .picker__select--year\').get(0).selectedIndex+1;JQuery(\'.bfCalendarResponsiveContainer' + fieldname + ' .picker__select--year\').trigger(\'change\')" border="0" src="' + bfPickerPlusYearIcon + '" style="width: 30px; vertical-align: top; cursor:pointer;" />');
+			}
+
+			JQuery('.bfCalendarResponsiveContainer' + fieldname + ' .picker__select--year').on('change', function () {
+				bf_add_yearscroller(fieldname);
+			});
+			JQuery('.bfCalendarResponsiveContainer' + fieldname + ' .picker__select--month').on('change', function () {
+				bf_add_yearscroller(fieldname);
+			});
+
+			var myVal = JQuery('.bfCalendarResponsiveContainer' + fieldname + ' .picker__select--year').val();
+			var myInterval = setInterval(function () {
+				if (myVal != JQuery('.bfCalendarResponsiveContainer' + fieldname + ' .picker__select--year').val()) {
+					clearInterval(myInterval);
+					bf_add_yearscroller(fieldname);
+				}
+			}, 200);
+
+			var myVal = JQuery('.bfCalendarResponsiveContainer' + fieldname + ' .picker__select--month').val();
+			var myInterval = setInterval(function () {
+				if (myVal != JQuery('.bfCalendarResponsiveContainer' + fieldname + ' .picker__select--month').val()) {
+					clearInterval(myInterval);
+					bf_add_yearscroller(fieldname);
+				}
+			}, 200);
+		}
+	}

--- a/media/com_breezingformsng/js/site/quickmode-flash-upload-mobile.js
+++ b/media/com_breezingformsng/js/site/quickmode-flash-upload-mobile.js
@@ -1,0 +1,70 @@
+/* Extracted from BFQuickModeMobile's inline process() script (Phase 9c
+   step 2b) - the chunked/queued file upload controller, only loaded when
+   the form has at least one bfFile element with flashUploader or html5
+   enabled. Kept separate from the classic/Bootstrap variant
+   (quickmode-flash-upload.js): the Mobile theme never toggles
+   #bfSubmitMessage's CSS display property, only its visibility and
+   z-index. */
+var bfUploaders = [];
+var bfUploaderErrorElements = [];
+var bfFlashUploadInterval = null;
+var bfFlashUploaders = new Array();
+var bfFlashUploadersLength = 0;
+function bfRefreshAll(){
+    for( var i = 0; i < bfUploaders.length; i++ ){
+        bfUploaders[i].refresh();
+    }
+}
+function bfInitAll(){
+    for( var i = 0; i < bfUploaders.length; i++ ){
+        bfUploaders[i].init();
+    }
+}
+function bfDoFlashUpload(){
+    JQuery("#bfSubmitMessage").css("visibility","hidden");
+    JQuery("#bfSubmitMessage").css("z-index","999999");
+    JQuery(".bfErrorMessage").html("");
+    JQuery(".bfErrorMessage").css("display","none");
+    for(var i = 0; i < bfUploaderErrorElements.length; i++){
+        JQuery("#"+bfUploaderErrorElements[i]).html("");
+    }
+    bfUploaderErrorElements = [];
+    if(ff_validation(0) == ""){
+        try{
+            bfFlashUploadInterval = window.setInterval( bfCheckFlashUploadProgress, 1000 );
+            if(bfFlashUploadersLength > 0){
+                JQuery("#bfFileQueue").bfcenter(true);
+                JQuery("#bfFileQueue").css("visibility","visible");
+                for( var i = 0; i < bfUploaders.length; i++ ){
+                    bfUploaders[i].start();
+                }
+            }
+        } catch(e){alert(e)}
+    } else {
+        if(typeof bfUseErrorAlerts == "undefined"){
+            alert(error);
+        } else {
+            bfShowErrors(error);
+        }
+        ff_validationFocus("");
+        document.getElementById("bfSubmitButton").disabled = false;
+    }
+}
+function bfCheckFlashUploadProgress(){
+    if( JQuery("#bfFileQueue").html() == "" ){ // empty indicates that all queues are uploaded or in any way cancelled
+        JQuery("#bfFileQueue").css("visibility","hidden");
+        window.clearInterval( bfFlashUploadInterval );
+        if(typeof bfAjaxObject101 != 'undefined' || typeof bfReCaptchaLoaded != 'undefined'){
+            ff_submitForm2();
+        }else{
+            ff_validate_submit(document.getElementById("bfSubmitButton"), "click");
+        }
+        JQuery(".bfFlashFileQueueClass").html("");
+        if(bfFlashUploadersLength > 0){
+            JQuery("#bfSubmitMessage").bfcenter(true);
+            JQuery("#bfSubmitMessage").css("visibility","visible");
+            JQuery("#bfSubmitMessage").css("z-index","999999");
+        }
+
+    }
+}

--- a/media/com_breezingformsng/js/site/quickmode-flash-upload-onepage.js
+++ b/media/com_breezingformsng/js/site/quickmode-flash-upload-onepage.js
@@ -1,0 +1,76 @@
+/* Extracted from BFQuickModeOnePage's inline process() script (Phase 9c
+   step 2b) - the chunked/queued file upload controller, only loaded when
+   the form has at least one bfFile element with flashUploader or html5
+   enabled. Kept separate from the classic/Bootstrap variant
+   (quickmode-flash-upload.js): OnePage always alert()s on validation
+   failure instead of respecting bfUseErrorAlerts/bfShowErrors, resets the
+   submit button's Ladda spinner (global `ladda_button`, set up elsewhere
+   in this theme's inline script) on failure, and calls this theme's own
+   bf_validate_submit() instead of the shared ff_validate_submit() once
+   all queued uploads finish. */
+var bfUploaders = [];
+var bfUploaderErrorElements = [];
+var bfFlashUploadInterval = null;
+var bfFlashUploaders = new Array();
+var bfFlashUploadersLength = 0;
+function bfRefreshAll(){
+    for( var i = 0; i < bfUploaders.length; i++ ){
+        bfUploaders[i].refresh();
+    }
+}
+function bfInitAll(){
+    for( var i = 0; i < bfUploaders.length; i++ ){
+        bfUploaders[i].init();
+    }
+}
+function bfDoFlashUpload(){
+    JQuery("#bfSubmitMessage").css("visibility","hidden");
+    JQuery("#bfSubmitMessage").css("display","none");
+    JQuery("#bfSubmitMessage").css("z-index","999999");
+    JQuery(".bfErrorMessage").html("");
+    JQuery(".bfErrorMessage").css("display","none");
+    for(var i = 0; i < bfUploaderErrorElements.length; i++){
+        JQuery("#"+bfUploaderErrorElements[i]).html("");
+    }
+    bfUploaderErrorElements = [];
+    if(ff_validation(0) == ""){
+        try{
+            bfFlashUploadInterval = window.setInterval( bfCheckFlashUploadProgress, 1000 );
+            if(bfFlashUploadersLength > 0){
+                JQuery("#bfFileQueue").bfcenter(true);
+                JQuery("#bfFileQueue").css("visibility","visible");
+                for( var i = 0; i < bfUploaders.length; i++ ){
+                    bfUploaders[i].start();
+                }
+            }
+        } catch(e){alert(e)}
+    } else {
+        if(typeof bfUseErrorAlerts == "undefined"){
+            alert(error);
+        } else {
+            alert(error);
+        }
+        ff_validationFocus("");
+        document.getElementById("bfSubmitButton").disabled = false;
+        ladda_button.ladda("stop");
+    }
+}
+function bfCheckFlashUploadProgress(){
+    if( JQuery("#bfFileQueue").html() == "" ){ // empty indicates that all queues are uploaded or in any way cancelled
+        JQuery("#bfFileQueue").css("visibility","hidden");
+        window.clearInterval( bfFlashUploadInterval );
+        if(typeof bfAjaxObject101 != 'undefined' || typeof bfReCaptchaLoaded != 'undefined'){
+            ff_submitForm2();
+        }else{
+            bf_validate_submit(document.getElementById("bfSubmitButton"), "click");
+        }
+        JQuery(".bfFlashFileQueueClass").html("");
+        if(bfFlashUploadersLength > 0){
+            JQuery("#bfSubmitMessage").bfcenter(true);
+            JQuery("#bfSubmitMessage").css("visibility","visible");
+            JQuery("#bfSubmitMessage").css("display","block");
+            JQuery("#bfSubmitMessage").css("z-index","999999");
+        }
+
+    }
+}

--- a/media/com_breezingformsng/js/site/quickmode-flash-upload.js
+++ b/media/com_breezingformsng/js/site/quickmode-flash-upload.js
@@ -1,0 +1,70 @@
+/* Extracted from BFQuickMode's inline process() script (Phase 9c step 2b) -
+   the chunked/queued file upload controller, only loaded when the form
+   has at least one bfFile element with flashUploader or html5 enabled
+   (see ClassicRenderer::hasFlashUpload). Despite the name, this also
+   covers the modern HTML5 upload path, not just legacy Flash. */
+var bfUploaders = [];
+var bfUploaderErrorElements = [];
+var bfFlashUploadInterval = null;
+var bfFlashUploaders = new Array();
+var bfFlashUploadersLength = 0;
+function bfRefreshAll(){
+    for( var i = 0; i < bfUploaders.length; i++ ){
+        bfUploaders[i].refresh();
+    }
+}
+function bfInitAll(){
+    for( var i = 0; i < bfUploaders.length; i++ ){
+        bfUploaders[i].init();
+    }
+}
+function bfDoFlashUpload(){
+    JQuery("#bfSubmitMessage").css("visibility","hidden");
+    JQuery("#bfSubmitMessage").css("display","none");
+    JQuery("#bfSubmitMessage").css("z-index","999999");
+    JQuery(".bfErrorMessage").html("");
+    JQuery(".bfErrorMessage").css("display","none");
+    for(var i = 0; i < bfUploaderErrorElements.length; i++){
+        JQuery("#"+bfUploaderErrorElements[i]).html("");
+    }
+    bfUploaderErrorElements = [];
+    if(ff_validation(0) == ""){
+        try{
+            bfFlashUploadInterval = window.setInterval( bfCheckFlashUploadProgress, 1000 );
+            if(bfFlashUploadersLength > 0){
+                JQuery("#bfFileQueue").bfcenter(true);
+                JQuery("#bfFileQueue").css("visibility","visible");
+                for( var i = 0; i < bfUploaders.length; i++ ){
+                    bfUploaders[i].start();
+                }
+            }
+        } catch(e){alert(e)}
+    } else {
+        if(typeof bfUseErrorAlerts == "undefined"){
+            alert(error);
+        } else {
+            bfShowErrors(error);
+        }
+        ff_validationFocus("");
+        document.getElementById("bfSubmitButton").disabled = false;
+    }
+}
+function bfCheckFlashUploadProgress(){
+    if( JQuery("#bfFileQueue").html() == "" ){ // empty indicates that all queues are uploaded or in any way cancelled
+        JQuery("#bfFileQueue").css("visibility","hidden");
+        window.clearInterval( bfFlashUploadInterval );
+        if(typeof bfAjaxObject101 != 'undefined' || typeof bfReCaptchaLoaded != 'undefined'){
+            ff_submitForm2();
+        }else{
+            ff_validate_submit(document.getElementById("bfSubmitButton"), "click");
+        }
+        JQuery(".bfFlashFileQueueClass").html("");
+        if(bfFlashUploadersLength > 0){
+            JQuery("#bfSubmitMessage").bfcenter(true);
+            JQuery("#bfSubmitMessage").css("visibility","visible");
+            JQuery("#bfSubmitMessage").css("display","block");
+            JQuery("#bfSubmitMessage").css("z-index","999999");
+        }
+
+    }
+}

--- a/media/com_breezingformsng/js/site/quickmode-onepage-switchpage.js
+++ b/media/com_breezingformsng/js/site/quickmode-onepage-switchpage.js
@@ -1,0 +1,13 @@
+/* Extracted from BFQuickModeOnePage's inline process() script (Phase 9c
+   step 2b) - the page-switching function specific to the OnePage theme's
+   navigation model (all pages present in the DOM at once, switched via
+   pointer-events/opacity instead of a real page reload). */
+function ff_switchpage(page){
+    for( var i = page; i > 0; i-- ){
+        JQuery("#bfPage"+i).css("pointer-events","auto");
+        JQuery("#bfPage"+i).css("opacity","1.0");
+    }
+    ff_currentpage = page;
+    ff_initialize("pageentry");
+    JQuery("#bfPage"+page).ScrollTo({offsetTop: 50});
+}

--- a/media/com_breezingformsng/js/site/quickmode-signature.js
+++ b/media/com_breezingformsng/js/site/quickmode-signature.js
@@ -1,0 +1,86 @@
+/* Extracted from BFQuickMode's inline process() script (Phase 9c step 2b)
+   - the signature-pad controller for a bfSignature element. Originally
+   emitted once per element with the element's dbId baked directly into
+   every function/variable name (bf_signaturePad123, bf_canvas123,
+   bf_resizeCanvas123Func, bf_Signature123Reset...), which meant the
+   exact same ~50 lines were re-declared for every signature field on a
+   form. Rewritten here as a single shared definition keyed by dbId
+   (bfSignaturePads[dbId], bfSignatureCanvases[dbId]), called once per
+   element via bfSignatureInit(dbId) - see the PHP side for the (much
+   smaller) per-element call site. Behaviour is otherwise unchanged,
+   including the three-way resize/restore contract: bfSignatureInit's
+   own calls pass restoreArg=false (just size the canvas, no restore),
+   while the window "resize" handler passes the resize Event object
+   (truthy, so the existing drawing is captured and restored across the
+   resize) - exactly as the original per-element functions did with
+   arguments[0]. The literal "base64" marker used to strip the data URL
+   prefix was originally built as 'ba'.'se'.'64' (obfuscated string
+   concatenation, presumably to dodge an over-eager hosting malware
+   scanner); it is always the constant string "base64" regardless of
+   which element renders it, so it's hardcoded directly here rather than
+   threaded through as a parameter. Shared by all 4 renderers -
+   Classic/Bootstrap/OnePage all had this exact logic including the
+   "if (canvas == null) return;" guard; MobileRenderer's per-element
+   copy was missing that guard (a latent null-dereference risk if the
+   canvas were ever absent, never actually observable on the success
+   path since the element always renders its own canvas), so this
+   shared version's guard now also protects Mobile - a safety-only
+   difference from Mobile's prior behaviour, not a functional one. */
+var bfSignaturePads = {};
+var bfSignatureCanvases = {};
+
+function bfSignatureResizeCanvas(dbId, restoreArg) {
+	var canvas = bfSignatureCanvases[dbId];
+	var pad = bfSignaturePads[dbId];
+	var data;
+
+	if (restoreArg !== false) {
+		data = pad.toDataURL();
+	}
+
+	var ratio = Math.max(window.devicePixelRatio || 1, 1);
+	canvas.width = canvas.offsetWidth * ratio;
+	canvas.height = canvas.offsetHeight * ratio;
+	canvas.getContext("2d").scale(ratio, ratio);
+
+	if (restoreArg !== false) {
+		pad.fromDataURL(data);
+		JQuery("#ff_elem" + dbId).val(data.replace("data:image/png;base64,", ""));
+	}
+
+	pad = bfSignaturePads[dbId] = new SignaturePad(canvas, {
+		backgroundColor: "rgb(255,255,255)",
+		penColor: "rgb(0,0,0)",
+		onEnd: function () {
+			var d = bfSignaturePads[dbId].toDataURL();
+			JQuery("#ff_elem" + dbId).val(d.replace("data:image/png;base64,", ""));
+		}
+	});
+}
+
+function bfSignatureReset(dbId) {
+	bfSignaturePads[dbId].clear();
+	JQuery("#ff_elem" + dbId).val("");
+}
+
+function bfSignatureInit(dbId) {
+	JQuery(document).ready(function () {
+		var canvas = document.querySelector("#bfSignature" + dbId + " canvas");
+		bfSignatureCanvases[dbId] = canvas;
+		if (canvas == null) return;
+
+		// trouble on mobile devices, thinks swiping is resize...
+		JQuery(window).on("resize", function (e) {
+			bfSignatureResizeCanvas(dbId, e);
+		});
+
+		bfSignatureResizeCanvas(dbId, false);
+
+		// make sure the canvas is resized if dimensions are zero
+		setInterval(function () {
+			if (canvas.width == 0 && canvas.height == 0) {
+				bfSignatureResizeCanvas(dbId, false);
+			}
+		}, 500);
+	});
+}


### PR DESCRIPTION
## Résumé

Phase 9c step 2b : extraction du JS **par élément** (au-delà des blocs globaux déjà faits dans les PR précédentes) hors des 4 renderers QuickMode legacy vers des assets statiques, avec vérification en direct sur le conteneur de dev pour chaque lot.

- **Upload flash/HTML5** (4 renderers) : contrôleur d'upload par lots, chargé seulement si un champ `bfFile` a l'upload par lots activé. Classic/Bootstrap partagent un fichier ; Mobile et OnePage ont chacun leur propre variante (différences de comportement historiques préservées : Mobile ne bascule jamais l'affichage CSS de la barre de progression, OnePage alerte toujours sur erreur + gère un spinner Ladda + appelle sa propre fonction de soumission).
- **Scroller année/mois du calendrier responsive** (Classic + Bootstrap/OnePage) : Bootstrap/OnePage partagent une variante préservant une coquille CSS préexistante (`vertical - align` avec espaces parasites) absente de Classic, plutôt que de la « corriger » au passage.
- **`ff_switchpage`** (OnePage uniquement) : fonction de navigation entre pages propre au modèle OnePage.
- **Contrôleur de signature électronique** (4 renderers) : seul vrai refactor du lot — passage de fonctions nommées par id de champ (`bf_signaturePad123`, `bf_resizeCanvas123Func`…) à un fichier partagé unique indexé par id, avec un point d'appel minuscule par élément. Une vraie différence de comportement trouvée (garde de sécurité contre canevas null manquante sur Mobile) et tranchée délibérément (préservée, documentée comme différence de sécurité uniquement).

## Vérifications

Chaque lot a été vérifié en conditions réelles sur le conteneur de dev (`joomla6-joomla-1`) :
- `php -l` / `node --check` sur tous les fichiers modifiés/créés
- diff ligne à ligne contre le bloc PHP original pour confirmer l'absence de changement de contenu (hors substitutions dynamiques explicitement documentées)
- rendu réel des formulaires 2/7/16/28 (Classic/Bootstrap), zéro nouvelle erreur console
- formulaire 35 temporairement basculé en mode OnePage pour tester `ff_switchpage` en direct, configuration restaurée après test
- élément `bfSignature` temporaire injecté dans le formulaire 28 pour tester dessin/valeur/réinitialisation/redimensionnement avant et après le refactor (valeurs identiques au caractère près), formulaire restauré et confirmé exempt de l'élément de test après coup

Détails complets (avec captures de résultats de test) dans `MIGRATION.md`.

## Périmètre restreint

N'ont pas été traités (documenté dans `MIGRATION.md`) : reCAPTCHA (instance unique par formulaire, dépend d'une clé de site Google réelle, pas de gain de mutualisation), formules `fieldCalc` et contenu des zones de texte enrichi (données propres à chaque formulaire, pas du code partageable).

🤖 Généré avec [Claude Code](https://claude.com/claude-code)
