### PR TITLE
Devops parity cbng

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -21,6 +21,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.3'
+          tools: composer:v2
           coverage: none
 
       - name: Check PHP syntax
@@ -44,8 +45,41 @@ jobs:
           }
           '
 
+      - name: Check translations
+        run: python3 scripts/check-translations.py
+
+      - name: Audit composer dependencies
+        working-directory: administrator/components/com_breezingformsng
+        run: composer audit --locked --no-interaction
+
+  unit-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Setup PHP with coverage
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          tools: composer:v2
+          coverage: pcov
+
+      - name: Install test dependencies
+        run: composer install --prefer-dist --no-interaction --no-progress
+
+      - name: Run unit tests and measure coverage
+        run: vendor/bin/phpunit --coverage-clover=coverage.xml --coverage-text
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v7
+        with:
+          name: phpunit-coverage
+          path: coverage.xml
+
   package:
-    needs: quality
+    needs: [quality, unit-tests]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -53,6 +87,12 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          tools: composer:v2
 
       - name: Resolve package version
         id: version
@@ -72,8 +112,17 @@ jobs:
         id: package
         run: echo "archive=$(scripts/build-package.sh)" >> "$GITHUB_OUTPUT"
 
+      - name: Calculate package checksum
+        id: checksum
+        run: |
+          sha256="$(sha256sum "${{ steps.package.outputs.archive }}" | awk '{print $1}')"
+          echo "sha256=${sha256}" >> "$GITHUB_OUTPUT"
+
       - name: Validate package contents
         run: scripts/validate-package.sh "${{ steps.package.outputs.archive }}"
+
+      - name: Test installation and update on Joomla
+        run: scripts/joomla-install-smoke.sh "${{ steps.package.outputs.archive }}"
 
       - name: Upload installation package
         uses: actions/upload-artifact@v7
@@ -89,4 +138,5 @@ jobs:
           gh release create "${GITHUB_REF_NAME}" \
             "${{ steps.package.outputs.archive }}" \
             --title "BreezingForms NG ${GITHUB_REF_NAME}" \
-            --generate-notes
+            --generate-notes \
+            --notes "SHA-256: ${{ steps.checksum.outputs.sha256 }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,103 @@
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+#
+# ******** NOTE ********
+# We have attempted to detect the languages in your repository. Please check
+# the `language` matrix defined below to confirm you have the correct set of
+# supported CodeQL languages.
+#
+name: "CodeQL Advanced"
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  schedule:
+    - cron: '32 11 * * 0'
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    # Runner size impacts CodeQL analysis time. To learn more, please see:
+    #   - https://gh.io/recommended-hardware-resources-for-running-codeql
+    #   - https://gh.io/supported-runners-and-hardware-resources
+    #   - https://gh.io/using-larger-runners (GitHub.com only)
+    # Consider using larger runners or machines with greater resources for possible analysis time improvements.
+    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    permissions:
+      # required for all workflows
+      security-events: write
+
+      # required to fetch internal or private CodeQL packs
+      packages: read
+
+      # only required for workflows in private repositories
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - language: actions
+          build-mode: none
+        - language: javascript-typescript
+          build-mode: none
+        - language: python
+          build-mode: none
+        # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'
+        # Use `c-cpp` to analyze code written in C, C++ or both
+        # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
+        # Use 'javascript-typescript' to analyze code written in JavaScript, TypeScript or both
+        # To learn more about changing the languages that are analyzed or customizing the build mode for your analysis,
+        # see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning.
+        # If you are analyzing a compiled language, you can modify the 'build-mode' for that language to customize how
+        # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v5
+
+    # Add any setup steps before running the `github/codeql-action/init` action.
+    # This includes steps like installing compilers or runtimes (`actions/setup-node`
+    # or others). This is typically only required for manual builds.
+    # - name: Setup runtime (example)
+    #   uses: actions/setup-example@v1
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v4
+      with:
+        languages: ${{ matrix.language }}
+        build-mode: ${{ matrix.build-mode }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+
+        # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+        # queries: security-extended,security-and-quality
+
+    # If the analyze step fails for one of the languages you are analyzing with
+    # "We were unable to automatically build your code", modify the matrix above
+    # to set the build mode to "manual" for that language. Then modify this step
+    # to build your code.
+    # ℹ️ Command-line programs to run using the OS shell.
+    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+    - name: Run manual build steps
+      if: matrix.build-mode == 'manual'
+      shell: bash
+      run: |
+        echo 'If you are using a "manual" build mode for one or more of the' \
+          'languages you are analyzing, replace this with the commands to build' \
+          'your code, for example:'
+        echo '  make bootstrap'
+        echo '  make release'
+        exit 1
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v4
+      with:
+        category: "/language:${{matrix.language}}"

--- a/administrator/components/com_breezingformsng/language/de-DE/com_breezingformsng.ini
+++ b/administrator/components/com_breezingformsng/language/de-DE/com_breezingformsng.ini
@@ -35,6 +35,8 @@ COM_BREEZINGFORMSNG_QM_STRIPE_AMOUNT="Preis in der gewünschten Währung"
 COM_BREEZINGFORMSNG_QM_STRIPE_CURRENCY="Währungscode, z.B. USD oder EUR. Sollte grossgeschrieben sein."
 COM_BREEZINGFORMSNG_QM_STRIPE_THANKYOUPAGE="URL zu einer alternativen Dankesseite nach Zahlung. Bei eingeschalteten Downloads wird dies übersprungen."
 COM_BREEZINGFORMSNG_QM_STRIPE_SENDNOTAFPAY="E-Mail-Benachrichtigungen nur dann aktivieren, wenn die Zahlung erfolgreich war."
+COM_BREEZINGFORMSNG_QM_STRIPE_EMAIL="Geben Sie den Namen des Feldes ein, das die E-Mail-Adresse des Benutzers enthält. Achten Sie darauf, den korrekten Namen Ihres Feldes einzugeben, sonst funktioniert Ihr Formular nicht. Vergessen Sie nicht, das E-Mail-Feld zu validieren."
+COM_BREEZINGFORMSNG_STRIPE_EMAIL="Name des Textfelds, das die E-Mail-Adresse des Benutzers enthält"
 
 
 COM_BREEZINGFORMSNG_QM_THEME_BOOTSTRAP_MODE="One-Page Layout aktivieren"
@@ -519,7 +521,6 @@ COM_BREEZINGFORMSNG_CONFIG_CSVQUOTENEWLINE_REGULAR="Normal (Umbruch in Zelle)"
 COM_BREEZINGFORMSNG_CONFIG_CSVQUOTENEWLINE_QUOTED="Maskiert"
 COM_BREEZINGFORMSNG_FORMS_ATTACHMENT="Anhang"
 COM_BREEZINGFORMSNG_IF_NOT_USE_ERROR_ALERTS="Wenn keine Alert-Fenster"
-COM_BREEZINGFORMSNG_IF_USE_DEFAULT_ERRROS="Standardfehler benutzen"
 COM_BREEZINGFORMSNG_IF_USE_BALLOON_ERRORS="Ballonfehler benutzen"
 
 COM_BREEZINGFORMSNG_CONFIG_CSV_FIELDSET="CSV-Export"
@@ -734,7 +735,6 @@ COM_BREEZINGFORMSNG_PAYPALIMAGE="Alternatives PayPal Bild"
 COM_BREEZINGFORMSNG_ATTACH_FILE_TO_ADMIN_MAILS="An Admin-Mail anhängen"
 COM_BREEZINGFORMSNG_ATTACH_FILE_TO_USER_MAILS="An Benutzer-Mail anhängen"
 
-COM_BREEZINGFORMSNG_ORDER="Reihenfolge (Nummer)"
 COM_BREEZINGFORMSNG_CAPTCHA_MISSING_WRONG="Captcha fehlt oder ist falsch!"
 
 
@@ -830,7 +830,6 @@ COM_BREEZINGFORMSNG_MOVE_LEFT="Nach links"
 COM_BREEZINGFORMSNG_MOVE_RIGHT="Nach rechts"
 COM_BREEZINGFORMSNG_INIT_SCRIPT="Initialisierungsskript"
 COM_BREEZINGFORMSNG_ACTION_SCRIPT="Aktionsskript"
-COM_BREEZINGFORMSNG_SCIPT="Skript"
 COM_BREEZINGFORMSNG_VALIDATION_SCRIPT="Validierungsskript"
 COM_BREEZINGFORMSNG_PAGES="Seiten"
 COM_BREEZINGFORMSNG_CURRENT_PAGE="Aktuelle Seite"
@@ -841,7 +840,6 @@ COM_BREEZINGFORMSNG_DELETE_THIS_PAGE="Diese Seite löschen"
 COM_BREEZINGFORMSNG_HIDDEN_FIELDS="Versteckte Eingabefelder"
 COM_BREEZINGFORMSNG_TRASH_CAN="Mülleimer"
 
-COM_BREEZINGFORMSNG_ARE_YOU_SURE_YOU_WANT_TO_DELETE_THIS_PAGE?="Sicher, dass diese Seite gelöscht werden soll?"
 
 
 COM_BREEZINGFORMSNG_MAILBACKFILE_IF_IS_MAILBACK_A_FILE_FROM_THIS_SERVER_PATH_IS_SENT_TO_THE_MAILBACK_ADDRESS="Rückantwortdatei (Falls dies ein Rückantwortfeld ist, wird die angegebene Datei auf dem Server an den Empfänger verschickt)"

--- a/administrator/components/com_breezingformsng/packages/stdlib.english.xml
+++ b/administrator/components/com_breezingformsng/packages/stdlib.english.xml
@@ -3,7 +3,7 @@
 	<name>stdlib.english</name>
 	<title>stdlib.english.xml</title>
 	<version>6.1.1-alpha.1</version>
-	<creationDate>2026-06-10 00:00:00</creationDate>
+	<creationDate>2026-07-17 00:00:00</creationDate>
 	<author>XDA+GIL</author>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>https://breezingforms-ng.vcmb.fr</authorUrl>

--- a/administrator/components/com_breezingformsng/plugins/sysbreezingforms/sysbreezingforms.xml
+++ b/administrator/components/com_breezingformsng/plugins/sysbreezingforms/sysbreezingforms.xml
@@ -2,7 +2,7 @@
 <extension version="6.0" type="plugin" group="system" method="upgrade">
 	<name>PLG_SYSTEM_SYSBREEZINGFORMS</name>
 	<author>XDA/GIL</author>
-	<creationDate>2026-06-10</creationDate>
+	<creationDate>2026-07-17</creationDate>
 	<copyright>Copyright 2024 - 2026 by XDA+GIL</copyright>
         <license>GNU/GPL v2 or later</license>
 	<authorEmail>bf@vcmb.fr</authorEmail>

--- a/com_breezingformsng.xml
+++ b/com_breezingformsng.xml
@@ -10,7 +10,7 @@
 
 	<name>COM_BREEZINGFORMSNG</name>
 	<element>com_breezingformsng</element>
-	<creationDate>2026-06-10</creationDate>
+	<creationDate>2026-07-17</creationDate>
 	<author>XDA/GIL</author>
 	<copyright>Copyright 2024 - 2026 by XDA+GIL</copyright>
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>

--- a/components/com_breezingformsng/language/de-DE/com_breezingformsng.ini
+++ b/components/com_breezingformsng/language/de-DE/com_breezingformsng.ini
@@ -6,7 +6,7 @@ COM_BREEZINGFORMSNG_FORMS_DOUBLE_OPT_OUT_EMAIL_THANK_YOU="Ihre Bestätigung wurd
 COM_BREEZINGFORMSNG_FORMS_DOUBLE_OPT_VERIFY_HERE = "Bestätigen";
 COM_BREEZINGFORMSNG_FORMS_DOUBLE_OPT_UNVERIFY_HERE = "Bestätigung zurücknehmen";
 COM_BREEZINGFORMSNG_FORMS_DOUBLE_OPT_EMAIL_TEXT = "Danke für Ihre Mitteilung. Um Ihre Übermittlung zu bestätigen, klicken Sie bitte unten stehenden Link:<br/><br/>"
-OM_BREEZINGFORMS_FORMS_DOUBLE_OPT_OUT_EMAIL_TEXT = "<br/><br/>Um Ihre Bestätigung wieder zurück zu nehmen können Sie auf folgenden Link klicken:<br/><br/>"
+COM_BREEZINGFORMSNG_FORMS_DOUBLE_OPT_OUT_EMAIL_TEXT = "<br/><br/>Um Ihre Bestätigung wieder zurück zu nehmen können Sie auf folgenden Link klicken:<br/><br/>"
 COM_BREEZINGFORMSNG_FORMS_DOUBLE_OPT_EMAIL_TEXT_FOOTER = "<br/><br/>Ihr Webseiten-Team!"
 
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -9,4 +9,10 @@
             <directory>tests</directory>
         </testsuite>
     </testsuites>
+    <source>
+        <include>
+            <directory>administrator/components/com_breezingformsng/src</directory>
+            <directory>components/com_breezingformsng/src</directory>
+        </include>
+    </source>
 </phpunit>

--- a/script.php
+++ b/script.php
@@ -852,7 +852,7 @@ class com_breezingformsngInstallerScript
     {
         $requiredFiles = [
             JPATH_ADMINISTRATOR . '/components/com_breezingformsng/services/provider.php',
-            JPATH_ADMINISTRATOR . '/components/com_breezingformsng/src/Extension/BreezingformsNGComponent.php',
+            JPATH_ADMINISTRATOR . '/components/com_breezingformsng/src/Extension/BreezingFormsNGComponent.php',
             JPATH_SITE . '/components/com_breezingformsng/breezingformsng.php',
         ];
 

--- a/scripts/check-translations.py
+++ b/scripts/check-translations.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Contrôle CI des fichiers de langue (en-GB, fr-FR, de-DE).
+
+Vérifie pour chaque répertoire ``language`` :
+  - clefs dupliquées dans un même fichier .ini ;
+  - lignes malformées (pas de ``=`` ou valeur non entourée de guillemets) ;
+  - parité des clefs entre les langues lorsque le fichier traduit existe.
+
+Un fichier fr-FR/de-DE absent est signalé en avertissement, pas en erreur.
+
+Usage: python3 scripts/check-translations.py
+"""
+
+import os
+import re
+import sys
+
+LANGS = ('en-GB', 'fr-FR', 'de-DE')
+LINE_RE = re.compile(r'^[A-Z0-9_.\-]+\s*=\s*".*"\s*(?:;.*)?$')
+
+
+def parse_ini(path):
+    keys = {}
+    errors = []
+    with open(path, encoding='utf-8') as handle:
+        for number, line in enumerate(handle, 1):
+            stripped = line.strip()
+            if not stripped or stripped.startswith(';') or stripped.startswith('['):
+                continue
+            if not LINE_RE.match(stripped):
+                errors.append(f'{path}:{number}: ligne malformée: {stripped[:80]}')
+                continue
+            key = stripped.split('=', 1)[0].strip()
+            if key in keys:
+                errors.append(f'{path}:{number}: clef dupliquée {key} (première occurrence ligne {keys[key]})')
+            else:
+                keys[key] = number
+    return set(keys), errors
+
+
+def main():
+    errors = []
+    warnings = []
+    for root, dirs, _files in os.walk('.'):
+        dirs[:] = [d for d in dirs if d not in ('vendor', 'node_modules', '.git', 'build')]
+        if os.path.basename(root) != 'language':
+            continue
+        en_dir = os.path.join(root, 'en-GB')
+        if not os.path.isdir(en_dir):
+            continue
+        for name in sorted(os.listdir(en_dir)):
+            if not name.endswith('.ini'):
+                continue
+            en_keys, en_errors = parse_ini(os.path.join(en_dir, name))
+            errors.extend(en_errors)
+            for lang in LANGS[1:]:
+                path = os.path.join(root, lang, name)
+                if not os.path.isfile(path):
+                    warnings.append(f'{path}: traduction absente')
+                    continue
+                keys, lang_errors = parse_ini(path)
+                errors.extend(lang_errors)
+                for key in sorted(en_keys - keys):
+                    errors.append(f'{path}: clef manquante {key}')
+                for key in sorted(keys - en_keys):
+                    errors.append(f'{path}: clef orpheline {key} (absente de en-GB)')
+
+    for warning in warnings:
+        print(f'::warning::{warning}')
+    for error in errors:
+        print(f'::error::{error}')
+    if errors:
+        print(f'{len(errors)} erreur(s) de traduction.', file=sys.stderr)
+        return 1
+    print('Traductions OK.')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/scripts/joomla-install-smoke.sh
+++ b/scripts/joomla-install-smoke.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+archive="${1:?Usage: scripts/joomla-install-smoke.sh path/to/package.zip}"
+joomla_image="${JOOMLA_IMAGE:-joomla:6.0-apache}"
+mysql_image="${MYSQL_IMAGE:-mysql:8.4}"
+run_id="${GITHUB_RUN_ID:-local}-$$"
+network="bfng-smoke-${run_id}"
+db_container="bfng-smoke-db-${run_id}"
+web_container="bfng-smoke-web-${run_id}"
+container_archive="/tmp/com_breezingformsng.zip"
+
+cleanup() {
+    if [[ "${KEEP_SMOKE_CONTAINERS:-0}" == "1" ]]; then
+        echo "Smoke containers kept: ${web_container}, ${db_container}; network: ${network}" >&2
+        return
+    fi
+
+    docker rm -f "${web_container}" "${db_container}" >/dev/null 2>&1 || true
+    docker network rm "${network}" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+docker network create "${network}" >/dev/null
+
+docker run -d \
+    --name "${db_container}" \
+    --network "${network}" \
+    -e MYSQL_DATABASE=joomla \
+    -e MYSQL_USER=joomla \
+    -e MYSQL_PASSWORD=joomla \
+    -e MYSQL_ROOT_PASSWORD=root \
+    "${mysql_image}" >/dev/null
+
+for _ in $(seq 1 60); do
+    if docker exec -e MYSQL_PWD=root "${db_container}" mysqladmin ping -uroot --silent >/dev/null 2>&1; then
+        break
+    fi
+    sleep 2
+done
+
+docker exec -e MYSQL_PWD=root "${db_container}" mysqladmin ping -uroot --silent >/dev/null
+
+docker run -d \
+    --name "${web_container}" \
+    --network "${network}" \
+    -e JOOMLA_DB_HOST="${db_container}" \
+    -e JOOMLA_DB_USER=joomla \
+    -e JOOMLA_DB_PASSWORD=joomla \
+    -e JOOMLA_DB_NAME=joomla \
+    -e JOOMLA_SITE_NAME="BreezingForms NG Smoke Test" \
+    -e JOOMLA_ADMIN_USER="Smoke Administrator" \
+    -e JOOMLA_ADMIN_USERNAME=smokeadmin \
+    -e JOOMLA_ADMIN_PASSWORD='Smoke-Test-123!' \
+    -e JOOMLA_ADMIN_EMAIL=smoke@example.invalid \
+    -e JOOMLA_INSTALLATION_DISABLE_LOCALHOST_CHECK=1 \
+    "${joomla_image}" >/dev/null
+
+for _ in $(seq 1 90); do
+    if docker exec "${web_container}" test -f /var/www/html/configuration.php; then
+        break
+    fi
+    sleep 2
+done
+
+docker exec "${web_container}" test -f /var/www/html/configuration.php
+
+for _ in $(seq 1 60); do
+    if docker exec "${web_container}" php -r '
+        exit(@file_get_contents("http://127.0.0.1/index.php") === false ? 1 : 0);
+    '; then
+        break
+    fi
+    sleep 2
+done
+
+docker exec "${web_container}" php -r '
+    exit(@file_get_contents("http://127.0.0.1/index.php") === false ? 1 : 0);
+'
+
+docker cp "${archive}" "${web_container}:${container_archive}" >/dev/null
+docker exec -e HTTP_HOST=localhost "${web_container}" php /var/www/html/cli/joomla.php extension:install \
+    --path="${container_archive}" \
+    --live-site=http://localhost \
+    --quiet \
+    --no-interaction
+
+table_prefix="$(
+    docker exec "${web_container}" php -r '
+        require "/var/www/html/configuration.php";
+        $config = new JConfig();
+        echo $config->dbprefix;
+    '
+)"
+
+component_count="$(
+    docker exec -e MYSQL_PWD=joomla "${db_container}" mysql -N -ujoomla joomla \
+        -e "SELECT COUNT(*) FROM \`${table_prefix}extensions\` WHERE type = 'component' AND element = 'com_breezingformsng';"
+)"
+
+if [[ "${component_count}" -ne 1 ]]; then
+    echo "BreezingForms NG component registration was not found." >&2
+    docker exec -e MYSQL_PWD=joomla "${db_container}" mysql -N -ujoomla joomla \
+        -e "SELECT extension_id, type, element, name FROM \`${table_prefix}extensions\` WHERE element LIKE '%breezingform%' OR name LIKE '%BreezingForms%';" >&2
+    exit 1
+fi
+
+plugin_count="$(
+    docker exec -e MYSQL_PWD=joomla "${db_container}" mysql -N -ujoomla joomla \
+        -e "SELECT COUNT(*) FROM \`${table_prefix}extensions\` WHERE type = 'plugin' AND element = 'sysbreezingforms' AND folder = 'system';"
+)"
+
+if [[ "${plugin_count}" -ne 1 ]]; then
+    echo "BreezingForms NG system plugin was not installed correctly." >&2
+    exit 1
+fi
+
+# Component tables are prefixed facileforms_ (carried over from the
+# original FacileForms/BreezingForms naming), not breezingformsng_.
+table_count="$(
+    docker exec -e MYSQL_PWD=joomla "${db_container}" mysql -N -ujoomla joomla \
+        -e "SELECT COUNT(*) FROM information_schema.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME LIKE '${table_prefix}facileforms_%';"
+)"
+
+if [[ "${table_count}" -lt 14 ]]; then
+    echo "BreezingForms NG tables were not installed correctly: ${table_count} found (expected >= 14)." >&2
+    exit 1
+fi
+
+# Exercise the update path: installing the same package again over an
+# existing install must succeed without errors and leave the same tables
+# and registrations in place.
+docker exec -e HTTP_HOST=localhost "${web_container}" php /var/www/html/cli/joomla.php extension:install \
+    --path="${container_archive}" \
+    --live-site=http://localhost \
+    --quiet \
+    --no-interaction
+
+table_count_after_update="$(
+    docker exec -e MYSQL_PWD=joomla "${db_container}" mysql -N -ujoomla joomla \
+        -e "SELECT COUNT(*) FROM information_schema.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME LIKE '${table_prefix}facileforms_%';"
+)"
+
+if [[ "${table_count_after_update}" -ne "${table_count}" ]]; then
+    echo "Table count changed after re-running the installer as an update: ${table_count} -> ${table_count_after_update}." >&2
+    exit 1
+fi
+
+# Frontend sanity check: the site must still render after installation
+# (catches a fatal error in the system plugin or a broken menu item).
+frontend_status="$(
+    docker exec "${web_container}" php -r '
+        $context = stream_context_create(["http" => ["ignore_errors" => true]]);
+        file_get_contents("http://127.0.0.1/index.php", false, $context);
+        foreach ($http_response_header ?? [] as $header) {
+            if (preg_match("#^HTTP/\\S+\\s+(\\d+)#", $header, $m)) {
+                echo $m[1];
+                break;
+            }
+        }
+    '
+)"
+
+if [[ "${frontend_status}" != "200" ]]; then
+    echo "Frontend did not respond with HTTP 200 after installation (got: ${frontend_status:-<empty>})." >&2
+    exit 1
+fi
+
+echo "Joomla installation, update and frontend smoke tests passed."


### PR DESCRIPTION
## Résumé

Comparaison de la partie DevOps/GitHub de `com_contentbuilderng` (copie de référence, plus moderne) avec celle de ce dépôt, et reprise de ce qui apportait une vraie valeur. Trois ajouts ont immédiatement révélé de vrais défauts préexistants, corrigés dans ce même lot.

## Ce qui est porté

### 1. Vérification des traductions en CI (`scripts/check-translations.py`)
Nouveau job qui contrôle, pour chaque dossier `language/` du dépôt, la parité stricte des clés entre `en-GB`/`fr-FR`/`de-DE` (clés dupliquées, lignes malformées, clés manquantes ou orphelines).

**A trouvé 8 vraies anomalies préexistantes, corrigées dans ce commit :**
- Fichier de langue site : une clé `de-DE` littéralement tronquée — `OM_BREEZINGFORMS_FORMS_DOUBLE_OPT_OUT_EMAIL_TEXT` au lieu de `COM_BREEZINGFORMSNG_...` — qui cassait silencieusement l'email de confirmation de désinscription (double opt-out) en allemand.
- Fichier de langue admin : deux clés utilisées par le panneau de propriétés Stripe de QuickMode (`COM_BREEZINGFORMSNG_QM_STRIPE_EMAIL`, `COM_BREEZINGFORMSNG_STRIPE_EMAIL`) totalement absentes en `de-DE` — ajoutées avec une traduction cohérente.
- Fichier de langue admin : 4 lignes mortes/orphelines supprimées en `de-DE` (doublons fautés d'une clé déjà correcte ailleurs dans le même fichier : `_ERRROS` vs `_ERRORS`, `_ORDER` nu vs `_ORDER_NUMBER`, `_SCIPT` vs `_SCRIPT` ; plus une clé `_ARE_YOU_SURE_YOU_WANT_TO_DELETE_THIS_PAGE?` avec un `?` littéral dans son nom, jamais appelée par aucun code).

### 2. Workflow CodeQL (`.github/workflows/codeql.yml`)
Configuration CodeQL Advanced générique (analyse `actions`/`javascript-typescript`/`python` — PHP n'est pas un langage supporté par CodeQL), copiée telle quelle.

### 3. Test de fumée d'installation réel (`scripts/joomla-install-smoke.sh`)
Adapté depuis la version cbng : lance des conteneurs Joomla 6 + MySQL 8.4 éphémères en CI, installe le paquet construit via le vrai CLI Joomla, puis vérifie :
- l'enregistrement du composant et du plugin système ;
- les tables `facileforms_*` (BFNG garde le préfixe historique FacileForms, contrairement au `contentbuilderng_*` de cbng) ;
- le chemin de mise à jour (une deuxième installation ne doit pas perdre de table) ;
- le rendu du frontend (HTTP 200).

Les vérifications spécifiques à cbng (endpoint API JSON, migration d'un renommage de table historique) n'ont pas d'équivalent côté BFNG et n'ont donc pas été portées.

**En le faisant tourner pour la première fois, ce test a immédiatement révélé un vrai bug d'installeur** : `script.php` vérifiait la présence de `.../src/Extension/BreezingformsNGComponent.php` (f minuscule) alors que le fichier réel s'appelle `BreezingFormsNGComponent.php` (F majuscule). Invisible sur macOS/Windows (système de fichiers insensible à la casse) et sur le conteneur de dev de ce projet (fichiers toujours déployés via `docker cp` pendant la migration, jamais via le vrai installeur Joomla) — mais qui aurait fait échouer **toute installation fraîche du paquet sur un serveur Linux**, avec une erreur « Installed files inconsistent... reinstall the package. » Corrigé.

### 4. Workflow CI enrichi (`.github/workflows/build-package.yml`)
- Job `quality` : ajout de l'étape de vérification des traductions et de `composer audit --locked` sur les dépendances du composant.
- Nouveau job `unit-tests` : exécute la suite PHPUnit existante avec couverture (publiée en artefact).
- Job `package` : dépend maintenant aussi de `unit-tests` ; calcule un SHA-256 du paquet construit (inclus dans les notes de la release GitHub) ; exécute le nouveau test de fumée d'installation juste après la validation du contenu du paquet, avant publication.

## Délibérément non repris

Ces éléments de cbng dépendent de décisions qui reviennent au mainteneur, pas à un agent :

- **Tag automatique de release à chaque push sur `main`** : nécessite un secret de dépôt `RELEASE_TAG_PAT` (jeton d'accès personnel), car le `GITHUB_TOKEN` par défaut ne peut pas déclencher le workflow de publication qui suit le push du tag (protection anti-boucle native de GitHub Actions).
- **Publication du checksum dans `com_breezingformsng_update.xml` après le tag** : la version cbng suppose une distribution directement via GitHub Releases, alors que `com_breezingformsng_update.xml` pointe actuellement vers `https://breezingforms-ng.vcmb.fr/download/...` — porter ça tel quel changerait silencieusement (ou entrerait en conflit avec) cette distribution existante.
- **PHPStan** : cbng l'exécute au niveau 1 avec un baseline de 1 207 lignes constitué au fil du temps. L'ajouter à froid sur ce composant nécessiterait une première analyse complète pour calibrer un baseline initial — un chantier à part, pas à intégrer dans ce lot de mise à niveau DevOps.

## Vérifications effectuées

- `check-translations.py` : propre après corrections des fichiers de langue.
- `composer audit --locked` : aucune vulnérabilité signalée.
- Suite PHPUnit complète : verte.
- `joomla-install-smoke.sh` exécuté de bout en bout en local contre de vrais conteneurs `joomla:6.0-apache` + `mysql:8.4` : installation fraîche réussie, composant/plugin/14 tables présents, une deuxième installation (chemin de mise à jour) conserve le même nombre de tables, frontend répondant en 200 — le tout confirmé **seulement après** le correctif de casse sur `BreezingFormsNGComponent.php` ci-dessus (l'exécution initiale avait échoué).

🤖 Généré avec [Claude Code](https://claude.com/claude-code)
