### PR TITLE
Phase 9c: extract per-element QuickMode scripts (calendar responsive,…

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -897,6 +897,97 @@ Chiffres mesurés le 2026-07-12 sur l'état actuel du dépôt.
   > formules `fieldCalc` personnalisées, calendrier/signature/reCAPTCHA) — génuinement dynamiques, dépendent
   > de la configuration de chaque champ, extraction jugée plus délicate/risquée et pas encore entamée. La
   > réécriture native complète (au-delà de la seule extraction JS) reste le chantier de fond, non commencé.
+  >
+  > **Première extraction par élément (2026-07-18)** : l'initialiseur `pickadate()` du champ
+  > `bfCalendarResponsive` était byte-identique entre `ClassicRenderer`/`BootstrapRenderer`/`OnePageRenderer`
+  > (modulo indentation) — seuls `dbId`, `format`, `selectYears`, `firstDay` variaient — et `MobileRenderer`
+  > n'en différait que par l'absence du hook `onOpen` (pas de year-scroller sur ce thème, cf. note existante
+  > plus haut). Extrait vers `bfInitCalendarResponsive(dbId, options)` dans
+  > `media/com_breezingformsng/js/site/quickmode-calendar-responsive-init.js`, appelé avec un objet de
+  > configuration JSON par champ (`format`/`selectYears`/`firstDay`/`hasYearScroller`) ; la variable PHP
+  > `$container` (append du conteneur du picker) est désormais construite dans la fonction JS à partir de
+  > `dbId` plutôt que dupliquée par PHP. `MobileRenderer` charge aussi ce nouvel asset (il n'avait auparavant
+  > aucun fichier JS calendrier partagé) avec `hasYearScroller: false`. Vérifié : `php -l` propre sur les 4
+  > renderers ; en conditions réelles sur le formulaire 28 (Bootstrap, champ « Responsive calendar Eddy »,
+  > `dbId` 4807) — asset chargé, `bfInitCalendarResponsive` défini, ouverture du picker déclenche bien
+  > `onOpen` → `bf_add_yearscroller(4807)` → icône `#bfCalExt4807` injectée, zéro erreur console. Classic,
+  > Mobile et OnePage vérifiés par lecture de code uniquement (même patron, pas de champ de test disponible
+  > sur ces thèmes) — à revérifier en direct si l'occasion se présente.
+  >
+  > **Formulaire de test permanent reCAPTCHA créé (2026-07-18)** : aucun formulaire publié sur le site de
+  > dev n'a de champ `bfReCaptcha`, rendant impossible toute vérification en direct de cette famille
+  > d'éléments. Créé `PermanentReCaptchaTest` (id 86, thème Bootstrap, un seul champ reCAPTCHA visible,
+  > clé de test Google officielle publique — `6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI`/
+  > `6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe`, toujours valide, documentée par Google pour l'automatisation
+  > de tests, sans risque ni quota réel). Cloné à partir de la structure racine/page du formulaire 28 (déjà
+  > vérifiée fonctionnelle), avec un seul enfant `bfReCaptcha` construit depuis le template par défaut de
+  > l'éditeur QuickMode (`quickmode-elements.js::createReCaptcha`). **Ne pas supprimer** : accessible sans
+  > menu via `index.php?option=com_breezingformsng&view=form&ff_form=86` (`ff_form` sélectionne un
+  > formulaire par id, indépendamment de tout élément de menu — cf. `FormRenderer.php`). Utilisateur
+  > `claude-test` (Super User) : mot de passe redéfini en session pour tenter une connexion admin, mais
+  > l'accès `/administrator` a été bloqué par le classificateur de permissions de l'environnement (même
+  > blocage que celui déjà documenté pour les tests ACL) ; le formulaire a donc été construit directement en
+  > base plutôt que via l'éditeur QuickMode admin.
+  >
+  > **Extraction de l'initialiseur reCAPTCHA visible (2026-07-18)** : la branche « visible » (case à cocher,
+  > par opposition à l'invisible) du bloc `bfReCaptcha` était identique entre `ClassicRenderer`/
+  > `BootstrapRenderer`/`MobileRenderer`/`OnePageRenderer`, à une différence près : `ClassicRenderer` seul
+  > passe un second argument `true` à `grecaptcha.render()` (comportement non documenté, jamais expliqué
+  > ailleurs dans ce fichier — préservé tel quel via un flag `resetOnRerender` plutôt qu'investigué/corrigé,
+  > conformément à la règle de non-modification du comportement pendant une extraction JS). Extrait vers
+  > `bfInitVisibleReCaptcha(options)` dans `media/com_breezingformsng/js/site/quickmode-recaptcha-visible.js`,
+  > appelé avec `{sitekey, theme, size, resetOnRerender}` par thème. La variable PHP `$lang` (calculée dans
+  > les 4 renderers mais jamais utilisée dans le JS émis, y compris avant cette extraction) n'a pas été
+  > reproduite dans le JS — code mort déjà présent, non ajouté par ce changement. La branche « invisible »
+  > (`invisibleCaptcha`) n'a **pas** été touchée : `MobileRenderer` y diffère structurellement des 3 autres
+  > thèmes (injection DOM différente, pas de `expired-callback`, badge toujours `inline`), une vraie
+  > divergence de comportement à traiter séparément plutôt qu'une extraction mécanique. Vérifié : `php -l`
+  > propre sur les 4 renderers ; **en conditions réelles** sur le nouveau formulaire de test permanent
+  > (id 86, Bootstrap) : widget reCAPTCHA rendu (case à cocher « Je ne suis pas un robot », mention Google
+  > « clé de test »), 2 iframes chargées, `bfInitVisibleReCaptcha` défini, zéro erreur console avant et après
+  > déploiement du changement. Classic/Mobile/OnePage vérifiés par lecture de code uniquement (formulaire de
+  > test actuellement en thème Bootstrap) — à revérifier en direct si l'occasion se présente.
+  >
+  > **Extraction de l'initialiseur reCAPTCHA invisible (2026-07-18)** : contrairement à la branche visible,
+  > les 4 thèmes divergent réellement ici, pas seulement par whitespace. `ClassicRenderer` et
+  > `BootstrapRenderer` sont identiques (fonction nommée `recaptchaCheckedCallback(token)` qui remet
+  > `bfInvisibleRecaptcha` à `false` seulement si `token != ''`). `OnePageRenderer` utilise un callback
+  > anonyme inline qui **ne remet jamais** ce flag à `false` — différence de comportement préexistante,
+  > jamais documentée ni expliquée ailleurs dans ce fichier, préservée telle quelle via un paramètre
+  > `resetFlagOnCallback` plutôt que silencieusement unifiée (cohérent avec la règle déjà appliquée à la
+  > garde `canvas == null` de la signature Mobile). `MobileRenderer` diverge structurellement plus encore :
+  > injection dynamique des conteneurs via jQuery (`.append()`) au lieu d'un echo statique, masquage du
+  > wrapper du champ (`#bfElemWrap<dbId>`), aucun `expired-callback`, badge toujours codé en dur `"inline"`.
+  > Résultat : deux fichiers plutôt qu'un seul avec des flags à l'infini —
+  > `quickmode-recaptcha-invisible.js` (`bfInitInvisibleReCaptcha`, partagé Classic/Bootstrap/OnePage) et
+  > `quickmode-recaptcha-invisible-mobile.js` (`bfInitInvisibleReCaptchaMobile`, dédié). La variable PHP
+  > `$lang` (calculée mais jamais utilisée dans le JS émis, dans les 4 renderers) n'a pas été reproduite —
+  > code mort déjà présent avant ce changement, pas ajouté par lui.
+  >
+  > **Deuxième formulaire de test permanent créé** : `PermanentReCaptchaInvisibleTest` (id 87, thème
+  > Bootstrap, badge `inline`, même clé de test Google que le formulaire 86), cloné à partir du formulaire 86
+  > avec `invisibleCaptcha` activé. Accessible via
+  > `index.php?option=com_breezingformsng&view=form&ff_form=87`. **Ne pas supprimer.** Vérifié en conditions
+  > réelles : `php -l` propre sur les 4 renderers ; sur ce formulaire, `bfInitInvisibleReCaptcha` défini,
+  > `window.bfInvisibleRecaptcha` correctement mis à `true`, 2 iframes Google chargées (widget invisible
+  > effectivement rendu), zéro erreur console avant et après déploiement (chemin `resetFlagOnCallback: true`,
+  > commun à Classic/Bootstrap). Le chemin `resetFlagOnCallback: false` (OnePage) et `MobileRenderer`
+  > vérifiés par lecture de code uniquement (formulaire de test en thème Bootstrap) — à revérifier en direct
+  > si l'occasion se présente, notamment en basculant temporairement le formulaire 87 en OnePage/Mobile comme
+  > cela avait été fait pour le formulaire 35 lors des lots précédents.
+  >
+  > **OnePage vérifié en direct (2026-07-18)** : formulaire 87 basculé temporairement
+  > (`themebootstrapMode: true`), rendu en Chrome headless — `bfInitInvisibleReCaptcha` appelé avec
+  > `"resetFlagOnCallback":false` comme attendu, 2 iframes Google chargées, zéro erreur console. Configuration
+  > restaurée à l'identique après vérification (`themebootstrapMode: false`).
+  >
+  > **Mobile non vérifiable en direct** : tentative de basculement (`mobileEnabled`/`forceMobile` à `true`
+  > + en-tête `User-Agent` iPhone via Playwright) — reproduit exactement la limitation déjà documentée dans
+  > la section « Vérification finale Phase 9 » de ce fichier : le rendu Mobile dépend de `bf_is_mobile()`
+  > côté serveur, qui n'est pas satisfait par un simple en-tête `User-Agent` Playwright (dépend d'un état de
+  > session/détection plus riche). Le rendu est resté Bootstrap malgré le basculement. Configuration
+  > restaurée à l'identique (`mobileEnabled`/`forceMobile: false`) après l'essai. `MobileRenderer` reste donc
+  > vérifié par lecture de code uniquement pour cette extraction, comme documenté plus haut.
 - [~] **Vérification finale Phase 9 (repasse du 2026-07-17)** : après la fusion de la PR #29 et les
   extractions Mobile/OnePage, repasse partielle en conditions réelles :
   - [x] Rendu Classic (formulaires 2/16) et Bootstrap (formulaires 7/28) : zéro erreur JS, assets attendus

--- a/components/com_breezingformsng/src/Service/Rendering/QuickMode/BootstrapRenderer.php
+++ b/components/com_breezingformsng/src/Service/Rendering/QuickMode/BootstrapRenderer.php
@@ -1289,23 +1289,14 @@ class BootstrapRenderer
 
                                 $http = 'https';
 
-                                $lang = Factory::getApplication()->getInput()->getString('lang', '');
-
                                 $getLangTag = Factory::getApplication()->getLanguage()->getTag();
                                 $getLangSlug = explode('-', $getLangTag);
                                 $reCaptchaLang = 'hl=' . $getLangSlug[0];
 
-                                if ($lang != '') {
-                                    $lang = ',lang: ' . json_encode($lang) . '';
-                                }
-                                $size = '';
-                                if ($mdata['size'] != '') {
-                                    $size = json_encode($mdata['size']);
-                                } else {
-                                    $normal = 'normal';
-                                    $size = json_encode($normal);
-                                }
+                                $size = (isset($mdata['size']) && $mdata['size'] != '') ? $mdata['size'] : 'normal';
+
                                 Factory::getApplication()->getDocument()->addScript($http . '://www.google.com/recaptcha/api.js?' . $reCaptchaLang . '&onload=onloadBFNewRecaptchaCallback&render=explicit', $type = "text/javascript", array('data-usercentrics' => 'reCAPTCHA'));
+                                Factory::getApplication()->getDocument()->addScript(Uri::root(true) . '/media/com_breezingformsng/js/site/quickmode-recaptcha-visible.js');
 
                                 echo '
                                                     <div style="display: inline-block !important; vertical-align: middle;">
@@ -1315,40 +1306,16 @@ class BootstrapRenderer
                                                                 </div>
                                                         </div>
                                                     </div>
-                                                    <script data-usercentrics="reCAPTCHA" type="text/javascript">
-                                                    <!--
-                                                    var onloadBFNewRecaptchaCallback = function() {
-                                                      grecaptcha.render(document.getElementById("newrecaptcha"), {
-                                                        "sitekey" : "' . $mdata['pubkey'] . '",
-                                                        "theme" : "' . (trim($mdata['theme']) == '' ? 'light' : trim($mdata['theme'])) . '",
-                                                        "size"	: ' . $size . ',
-                                                      });
-                                                    };
-                                                    JQuery(document).ready(function(){
-                                                        var rc_loaded = JQuery("script").filter(function () {
-														    return ((typeof JQuery(this).attr("src") != "undefined" && JQuery(this).attr("src").indexOf("recaptcha\/api.js") > 0) ? true : false);
-														}).length;
-
-														if (rc_loaded === 0) {
-															//JQuery.getScript("' . $http . '://www.google.com/recaptcha/api.js?' . $reCaptchaLang . '&onload=onloadBFNewRecaptchaCallback&render=explicit");
-														}
-                                                    });
-                                                    -->
-                                                  </script>';
+                                                    <script data-usercentrics="reCAPTCHA" type="text/javascript">bfInitVisibleReCaptcha(' . json_encode([
+                                    'sitekey' => $mdata['pubkey'],
+                                    'theme' => trim($mdata['theme']) == '' ? 'light' : trim($mdata['theme']),
+                                    'size' => $size,
+                                    'resetOnRerender' => false,
+                                ]) . ');</script>';
                             } else
                                 if (isset($mdata['invisibleCaptcha']) && $mdata['invisibleCaptcha']) {
 
                                     $http = 'https';
-
-                                    $lang = Factory::getApplication()->getInput()->getString('lang', '');
-                                    if ($lang != '') {
-                                        $lang = ',lang: ' . json_encode($lang) . '';
-                                    }
-
-                                    $callSubmit = 'ff_validate_submit(this, \'click\')';
-                                    if ($this->hasFlashUpload) {
-                                        $callSubmit = 'if(typeof bfAjaxObject101 == \'undefined\' && typeof bfReCaptchaLoaded == \'undefined\'){bfDoFlashUpload()}else{ff_validate_submit(this, \'click\')}';
-                                    }
 
                                     $badge = str_replace('invisible_', '', trim($mdata['theme']));
 
@@ -1369,36 +1336,16 @@ class BootstrapRenderer
                                                 <div id="bfInvisibleReCaptcha"></div>
                                         <?php
                                     }
+
+                                    Factory::getApplication()->getDocument()->addScript(Uri::root(true) . '/media/com_breezingformsng/js/site/quickmode-recaptcha-invisible.js');
                                     ?>
 
-                                            <script data-usercentrics="reCAPTCHA" type="text/javascript">
-                                                bfInvisibleRecaptcha = true;
-                                                var onloadBFNewRecaptchaCallback = function () {
-                                                    grecaptcha.render('bfInvisibleReCaptchaContainer', {
-                                                        'sitekey': '<?php echo $mdata['pubkey'] ?>',
-                                                        'expired-callback': recaptchaExpiredCallback,
-                                                        'callback': recaptchaCheckedCallback,
-                                                        "badge": "<?php echo $badge == 'red' ? '' : $badge; ?>",
-                                                        'size': 'invisible'
-                                                    });
-                                                };
-
-                                                function recaptchaCheckedCallback(token) {
-                                                    if (token != '') {
-                                                        bfInvisibleRecaptcha = false;
-                                                    }
-                                                    if (typeof bf_htmltextareainit != 'undefined') {
-                                                        bf_htmltextareainit();
-                                                    }
-                                            <?php echo $callSubmit; ?>;
-                                                }
-                                                ;
-
-                                                function recaptchaExpiredCallback() {
-                                                    grecaptcha.reset();
-                                                }
-                                                ;
-                                            </script>
+                                            <script data-usercentrics="reCAPTCHA" type="text/javascript">bfInitInvisibleReCaptcha(<?php echo json_encode([
+												'sitekey' => $mdata['pubkey'],
+												'badge' => $badge == 'red' ? '' : $badge,
+												'hasFlashUpload' => $this->hasFlashUpload,
+												'resetFlagOnCallback' => true,
+											]); ?>);</script>
                                             <script data-usercentrics="reCAPTCHA"
                                                 src="https://www.google.com/recaptcha/api.js?onload=onloadBFNewRecaptchaCallback&render=explicit" async
                                                 defer></script>
@@ -1521,7 +1468,6 @@ class BootstrapRenderer
                         $mdata['format'] = $this->bfCalendarToPickadateFormat($mdata['format']);
                         $pickerFirstDay = $this->bfCalendarToPickadateFirstDay(isset($mdata['firstDay']) ? $mdata['firstDay'] : '');
                         $pickerSelectYears = $this->bfCalendarSelectYears($mdata);
-                        $pickerFormat = json_encode($mdata['format']);
                         echo '<div class="' . $this->bsClass('controls') . ' ' . $this->bsClass('form-inline') . '">';
                         echo '<div class="' . $this->bsClass('form-group') . ' ' . $this->bsClass('other-form-group') . '">';
                         echo $label;
@@ -1552,42 +1498,21 @@ class BootstrapRenderer
                         echo '<button style="cursor:pointer !important;" type="button" id="ff_elem' . $mdata['dbId'] . '_calendarButton" class="bfCalendar ' . $this->bsClass('btn') . ' ' . $this->bsClass('btn-primary') . ' button" value="' . htmlentities($right, ENT_QUOTES, 'UTF-8') . '"><i class="' . $this->bsClass('icon-calendar') . '"></i>' . htmlentities($right == '...' ? '' : $right, ENT_QUOTES, 'UTF-8') . '</button>' . "\n";
                         echo '</div>' . "\n";
 
-                        $container = 'JQuery("body").append("<div class=\"bfCalendarResponsiveContainer' . $mdata['dbId'] . '\" style=\"display:block;position:absolute;left:-9999px;\"></div>");';
-
                         if (!$this->hasResponsiveDatePicker) {
                             Factory::getApplication()->getDocument()->getWebAssetManager()->addInlineScript(
                                 'var bfPickerMinusYearIcon = ' . json_encode(Uri::root(true) . '/components/com_breezingformsng/libraries/jquery/pickadate/minusyear.png') . ';'
                                 . "\n" . 'var bfPickerPlusYearIcon = ' . json_encode(Uri::root(true) . '/components/com_breezingformsng/libraries/jquery/pickadate/plusyear.png') . ';'
                             );
                             Factory::getApplication()->getDocument()->addScript(Uri::root(true) . '/media/com_breezingformsng/js/site/quickmode-calendar-responsive-legacy-style.js');
+                            Factory::getApplication()->getDocument()->addScript(Uri::root(true) . '/media/com_breezingformsng/js/site/quickmode-calendar-responsive-init.js');
                         }
 
-                        echo '<script type="text/javascript">
-                                                <!--
-                                                JQuery(document).ready(function () {
-                                                    ' . $container . '
-                                                    JQuery("#ff_elem' . $mdata['dbId'] . '_calendarButton").on("mousedown",function(event){
-                                                    event.preventDefault();})
-                                                    JQuery("#ff_elem' . $mdata['dbId'] . '_calendarButton").pickadate({
-                                                        format: ' . $pickerFormat . ',
-                                                        selectYears: ' . $pickerSelectYears . ',
-                                                        selectMonths: true,
-                                                        editable: true,
-                                                        firstDay: ' . $pickerFirstDay . ',
-                                                        container: ".bfCalendarResponsiveContainer' . $mdata['dbId'] . '",
-                                                        onClose: function() {
-                                                            JQuery("#ff_elem' . $mdata['dbId'] . '_calendarButton").blur();
-                                                        },
-                                                        onOpen: function() {
-                                                            bf_add_yearscroller( ' . json_encode($mdata['dbId']) . ' );
-                                                        },
-                                                        onSet: function() {
-                                                            JQuery("#ff_elem' . $mdata['dbId'] . '").val(this.get("value"));
-                                                        }
-                                                    });
-                                                });
-                                                //-->
-                                                </script>' . "\n";
+                        echo '<script type="text/javascript">bfInitCalendarResponsive(' . json_encode((int) $mdata['dbId']) . ', ' . json_encode([
+                            'format' => $mdata['format'],
+                            'selectYears' => $pickerSelectYears,
+                            'firstDay' => $pickerFirstDay,
+                            'hasYearScroller' => true,
+                        ]) . ');</script>' . "\n";
 
                         $this->hasResponsiveDatePicker = true;
 

--- a/components/com_breezingformsng/src/Service/Rendering/QuickMode/ClassicRenderer.php
+++ b/components/com_breezingformsng/src/Service/Rendering/QuickMode/ClassicRenderer.php
@@ -1072,65 +1072,30 @@ float:left;
 
 								$http = 'https'; // forcing https now
 
-								$lang = Factory::getApplication()->getInput()->getString('lang', '');
-
                                 $getLangTag = Factory::getApplication()->getLanguage()->getTag();
                                 $getLangSlug = explode('-', $getLangTag);
                                 $reCaptchaLang = 'hl='. $getLangSlug[0];
 
-								if ($lang != '') {
-									$lang = ',lang: ' . json_encode($lang) . '';
-								}
-								$size = '';
-                                if($mdata['size'] != '') {
-                                   $size = json_encode($mdata['size']);
-                                } else {
-                                    $normal = 'normal';
-                                    $size = json_encode($normal);
+								$size = (isset($mdata['size']) && $mdata['size'] != '') ? $mdata['size'] : 'normal';
 
-                                }
 								Factory::getApplication()->getDocument()->addScript($http.'://www.google.com/recaptcha/api.js?'.$reCaptchaLang.'&onload=onloadBFNewRecaptchaCallback&render=explicit', $type = "text/javascript", array('data-usercentrics' => 'reCAPTCHA'));
+								Factory::getApplication()->getDocument()->addScript(Uri::root(true) . '/media/com_breezingformsng/js/site/quickmode-recaptcha-visible.js');
 
 								echo '
                                                     <div style="display: inline-block !important; vertical-align: middle;">
                                                         <div id="newrecaptcha"></div>
                                                     </div>
-                                                    <script data-usercentrics="reCAPTCHA" type="text/javascript">
-                                                    <!--
-                                                    var onloadBFNewRecaptchaCallback = function() {
-                                                      grecaptcha.render(document.getElementById("newrecaptcha"), {
-                                                        "sitekey" : "' . $mdata['pubkey'] . '",
-                                                        "theme" : "' . (trim($mdata['theme']) == '' ? 'light' : trim($mdata['theme'])) . '",
-                                                        "size"	: ' . $size . ',
-                                                      },true);
-                                                    };
-                                                    JQuery(document).ready(function(){
-
-                                                        var rc_loaded = JQuery("script").filter(function () {
-														    return ((typeof JQuery(this).attr("src") != "undefined" && JQuery(this).attr("src").indexOf("recaptcha\/api.js") > 0) ? true : false);
-														}).length;
-
-														if (rc_loaded === 0) {
-															//JQuery.getScript("'.$http.'://www.google.com/recaptcha/api.js?'.$reCaptchaLang.'&onload=onloadBFNewRecaptchaCallback&render=explicit");
-														}
-                                                    });
-                                                    -->
-                                                  </script>';
+                                                    <script data-usercentrics="reCAPTCHA" type="text/javascript">bfInitVisibleReCaptcha(' . json_encode([
+									'sitekey' => $mdata['pubkey'],
+									'theme' => trim($mdata['theme']) == '' ? 'light' : trim($mdata['theme']),
+									'size' => $size,
+									'resetOnRerender' => true,
+								]) . ');</script>';
 							}
 							else
 							if (isset($mdata['invisibleCaptcha']) && $mdata['invisibleCaptcha']) {
 
 								$http = 'https';
-
-								$lang = Factory::getApplication()->getInput()->getString('lang', '');
-								if ($lang != '') {
-									$lang = ',lang: ' . json_encode($lang) . '';
-								}
-
-								$callSubmit = 'ff_validate_submit(this, \'click\')';
-								if ($this->hasFlashUpload) {
-									$callSubmit = 'if(typeof bfAjaxObject101 == \'undefined\' && typeof bfReCaptchaLoaded == \'undefined\'){bfDoFlashUpload()}else{ff_validate_submit(this, \'click\')}';
-								}
 
                                 $badge = str_replace('invisible_','', trim($mdata['theme']));
 
@@ -1147,33 +1112,15 @@ float:left;
                                     <div id="bfInvisibleReCaptcha"></div>
                                 <?php
                                 }
+
+								Factory::getApplication()->getDocument()->addScript(Uri::root(true) . '/media/com_breezingformsng/js/site/quickmode-recaptcha-invisible.js');
 								?>
-									<script data-usercentrics="reCAPTCHA" type="text/javascript">
-										bfInvisibleRecaptcha = true;
-										var onloadBFNewRecaptchaCallback = function (){
-											grecaptcha.render('bfInvisibleReCaptchaContainer', {
-												'sitekey': '<?php echo $mdata['pubkey'] ?>',
-												'expired-callback': recaptchaExpiredCallback,
-												'callback': recaptchaCheckedCallback,
-                                                "badge" : "<?php echo $badge == 'red' ? '' : $badge; ?>",
-												'size': 'invisible'
-											});
-										};
-										
-										function recaptchaCheckedCallback(token){
-											if(token!=''){
-												bfInvisibleRecaptcha = false;
-											}
-											if(typeof bf_htmltextareainit != 'undefined'){
-												bf_htmltextareainit();
-											}
-											<?php echo $callSubmit; ?>;
-										};
-										
-										function recaptchaExpiredCallback(){
-											grecaptcha.reset();
-										};
-									</script>
+									<script data-usercentrics="reCAPTCHA" type="text/javascript">bfInitInvisibleReCaptcha(<?php echo json_encode([
+										'sitekey' => $mdata['pubkey'],
+										'badge' => $badge == 'red' ? '' : $badge,
+										'hasFlashUpload' => $this->hasFlashUpload,
+										'resetFlagOnCallback' => true,
+									]); ?>);</script>
 									<script data-usercentrics="reCAPTCHA" src="https://www.google.com/recaptcha/api.js?onload=onloadBFNewRecaptchaCallback&render=explicit" async defer></script>
 									<?php
 							}
@@ -1256,7 +1203,6 @@ float:left;
 							$mdata['format'] = $this->bfCalendarToPickadateFormat($mdata['format']);
 							$pickerFirstDay = $this->bfCalendarToPickadateFirstDay(isset($mdata['firstDay']) ? $mdata['firstDay'] : '');
 							$pickerSelectYears = $this->bfCalendarSelectYears($mdata);
-							$pickerFormat = json_encode($mdata['format']);
 
 							$size = 'style="width: 65%;min-width: 65%;max-width: 65%;" ';
 							if ($mdata['size'] != '') {
@@ -1282,42 +1228,21 @@ float:left;
 							echo '<button type="button" id="ff_elem' . $mdata['dbId'] . '_calendarButton" class="bfCalendar btn btn-secondary" value="' . htmlentities($right, ENT_QUOTES, 'UTF-8') . '"><span>' . htmlentities($right, ENT_QUOTES, 'UTF-8') . '</span></button>' . "\n";
 							echo '</span>' . "\n";
 
-						$container = 'JQuery("body").append("<div class=\"bfCalendarResponsiveContainer' . $mdata['dbId'] . '\" style=\"display:block;position:absolute;left:-9999px;\"></div>");';
-
 						if (!$this->hasResponsiveDatePicker) {
 							Factory::getApplication()->getDocument()->getWebAssetManager()->addInlineScript(
 								'var bfPickerMinusYearIcon = ' . json_encode(Uri::root(true) . '/components/com_breezingformsng/libraries/jquery/pickadate/minusyear.png') . ';'
 								. "\n" . 'var bfPickerPlusYearIcon = ' . json_encode(Uri::root(true) . '/components/com_breezingformsng/libraries/jquery/pickadate/plusyear.png') . ';'
 							);
 							Factory::getApplication()->getDocument()->addScript(Uri::root(true) . '/media/com_breezingformsng/js/site/quickmode-calendar-responsive.js');
+							Factory::getApplication()->getDocument()->addScript(Uri::root(true) . '/media/com_breezingformsng/js/site/quickmode-calendar-responsive-init.js');
 						}
 
-	                        echo '<script type="text/javascript">
-	                                                <!--
-	                                                JQuery(document).ready(function () {
-	                                                    '.$container.'
-	                                                    JQuery("#ff_elem'.$mdata['dbId'].'_calendarButton").on("mousedown",function(event){
-	                                                    event.preventDefault();})
-	                                                    JQuery("#ff_elem'.$mdata['dbId'].'_calendarButton").pickadate({
-	                                                        format: '.$pickerFormat.',
-	                                                        selectYears: '.$pickerSelectYears.',
-	                                                        selectMonths: true,
-	                                                        editable: true,
-	                                                        firstDay: '.$pickerFirstDay.',
-	                                                        container: ".bfCalendarResponsiveContainer'.$mdata['dbId'].'",
-	                                                        onClose: function() {
-	                                                            JQuery("#ff_elem'.$mdata['dbId'].'_calendarButton").blur();
-	                                                        },
-	                                                        onOpen: function() {
-	                                                            bf_add_yearscroller( '.json_encode($mdata['dbId']).' );
-                                                        },
-                                                        onSet: function() {
-                                                            JQuery("#ff_elem'.$mdata['dbId'].'").val(this.get("value"));
-                                                        }
-                                                    });
-                                                });
-                                                //-->
-                                                </script>'."\n";
+						echo '<script type="text/javascript">bfInitCalendarResponsive(' . json_encode((int) $mdata['dbId']) . ', ' . json_encode([
+							'format' => $mdata['format'],
+							'selectYears' => $pickerSelectYears,
+							'firstDay' => $pickerFirstDay,
+							'hasYearScroller' => true,
+						]) . ');</script>' . "\n";
 
 						$this->hasResponsiveDatePicker = true;
 

--- a/components/com_breezingformsng/src/Service/Rendering/QuickMode/MobileRenderer.php
+++ b/components/com_breezingformsng/src/Service/Rendering/QuickMode/MobileRenderer.php
@@ -1188,97 +1188,41 @@ var toggleFieldsArray = ' . $this->toggleFields . ';
 
 								$http = 'https';
 
-								$lang = Factory::getApplication()->getInput()->getString('lang', '');
-
 								$getLangTag = Factory::getApplication()->getLanguage()->getTag();
 								$getLangSlug = explode('-', $getLangTag);
 								$reCaptchaLang = 'hl=' . $getLangSlug[0];
 
-								if ($lang != '') {
-									$lang = ',lang: ' . json_encode($lang) . '';
-								}
-								$size = '';
-								if ($mdata['size'] != '') {
-									$size = json_encode($mdata['size']);
-								} else {
-									$normal = 'normal';
-									$size = json_encode($normal);
+								$size = (isset($mdata['size']) && $mdata['size'] != '') ? $mdata['size'] : 'normal';
 
-								}
 								$this->addScript($http . '://www.google.com/recaptcha/api.js?' . $reCaptchaLang . '&onload=onloadBFNewRecaptchaCallback&render=explicit', $type = "text/javascript", array('data-usercentrics' => 'reCAPTCHA'));
+								$this->addScript(Uri::root(true) . '/media/com_breezingformsng/js/site/quickmode-recaptcha-visible.js');
 
 								echo '
                                                     <div style="display: inline-block !important; vertical-align: middle;">
                                                         <div id="newrecaptcha"></div>
                                                     </div>
-                                                    <script data-usercentrics="reCAPTCHA" type="text/javascript">
-                                                    <!--
-                                                    var onloadBFNewRecaptchaCallback = function() {
-                                                      grecaptcha.render(document.getElementById("newrecaptcha"), {
-                                                        "sitekey" : "' . $mdata['pubkey'] . '",
-                                                        "theme" : "' . (trim($mdata['theme']) == '' ? 'light' : trim($mdata['theme'])) . '",
-                                                        "size"	: ' . $size . ',
-                                                      });
-                                                    };
-                                                    JQuery(document).ready(function(){
-                                                        var rc_loaded = JQuery("script").filter(function () {
-														    return ((typeof JQuery(this).attr("src") != "undefined" && JQuery(this).attr("src").indexOf("recaptcha\/api.js") > 0) ? true : false);
-														}).length;
-
-														if (rc_loaded === 0) {
-															//JQuery.getScript("' . $http . '://www.google.com/recaptcha/api.js?' . $reCaptchaLang . '&onload=onloadBFNewRecaptchaCallback&render=explicit");
-														}
-                                                    });
-                                                    -->
-                                                  </script>';
+                                                    <script data-usercentrics="reCAPTCHA" type="text/javascript">bfInitVisibleReCaptcha(' . json_encode([
+									'sitekey' => $mdata['pubkey'],
+									'theme' => trim($mdata['theme']) == '' ? 'light' : trim($mdata['theme']),
+									'size' => $size,
+									'resetOnRerender' => false,
+								]) . ');</script>';
 
 							} else
 								if (isset($mdata['invisibleCaptcha']) && $mdata['invisibleCaptcha']) {
 
 									$http = 'https';
 
-									$lang = Factory::getApplication()->getInput()->getString('lang', '');
-									if ($lang != '') {
-										$lang = ',lang: ' . json_encode($lang) . '';
-									}
-
-									$callSubmit = 'ff_validate_submit(this, \'click\')';
-									if ($this->hasFlashUpload) {
-										$callSubmit = 'if(typeof bfAjaxObject101 == \'undefined\' && typeof bfReCaptchaLoaded == \'undefined\'){bfDoFlashUpload()}else{ff_validate_submit(this, \'click\')}';
-									}
-
 									$this->addScript($http . '://www.google.com/recaptcha/api.js?onload=onloadBFNewRecaptchaCallback&render=explicit', $type = "text/javascript", array('data-usercentrics' => 'reCAPTCHA'));
+									$this->addScript(Uri::root(true) . '/media/com_breezingformsng/js/site/quickmode-recaptcha-invisible-mobile.js');
 
-
-									echo '
-                                                    <script data-usercentrics="reCAPTCHA" type="text/javascript">
-                                                    <!--
-                                                    bfInvisibleRecaptcha = true;
-                                                    var onloadBFNewRecaptchaCallback = function() {
-                                                      grecaptcha.render("bfInvisibleReCaptchaContainer", {
-                                                        "sitekey" : "' . $mdata['pubkey'] . '",
-                                                        "size": "invisible",
-                                                        "theme" : "' . (trim($mdata['theme']) == '' ? 'light' : trim($mdata['theme'])) . '",
-                                                        "badge" : "inline",
-                                                        "callback" : function(){if(typeof bf_htmltextareainit != \'undefined\'){ bf_htmltextareainit() }' . $callSubmit . ' }
-                                                      });
-                                                    };
-
-                                                    JQuery(document).ready(function(){
-
-                                                        JQuery("#bfElemWrap' . $mdata['dbId'] . '").css("display","none");
-                                                        JQuery("#' . $this->p->form_id . '").append("<div id=\\"bfInvisibleReCaptchaContainer\\" ></div><div id=\\"bfInvisibleReCaptcha\\" class=\\"g-recaptcha\\" data-callback=\\"onloadBFNewRecaptchaCallback\\" data-size=\\"invisible\\" data-sitekey=\\"' . $mdata['pubkey'] . '\\"></div>");
-
-                                                        var rc_loaded = JQuery("script").filter(function () {
-														    return ((typeof JQuery(this).attr("src") != "undefined" && JQuery(this).attr("src").indexOf("recaptcha\/api.js") > 0) ? true : false);
-														}).length;
-
-														if (rc_loaded === 0) {
-															//JQuery.getScript("' . $http . '://www.google.com/recaptcha/api.js?onload=onloadBFNewRecaptchaCallback&render=explicit");
-														}
-                                                    });
-                                                    -->
-                                                  </script>';
+									echo '<script data-usercentrics="reCAPTCHA" type="text/javascript">bfInitInvisibleReCaptchaMobile(' . json_encode([
+										'sitekey' => $mdata['pubkey'],
+										'theme' => trim($mdata['theme']) == '' ? 'light' : trim($mdata['theme']),
+										'hasFlashUpload' => $this->hasFlashUpload,
+										'dbId' => (int) $mdata['dbId'],
+										'formId' => $this->p->form_id,
+									]) . ');</script>';
 								}
 						} else {
 							echo '<span class="bfCaptcha">' . "\n";
@@ -1414,7 +1358,6 @@ var toggleFieldsArray = ' . $this->toggleFields . ';
 							$mdata['format'] = $this->bfCalendarToPickadateFormat($mdata['format']);
 							$pickerFirstDay = $this->bfCalendarToPickadateFirstDay(isset($mdata['firstDay']) ? $mdata['firstDay'] : '');
 							$pickerSelectYears = $this->bfCalendarSelectYears($mdata);
-							$pickerFormat = json_encode($mdata['format']);
 
 							$exploded = explode('::', trim($mdata['value']));
 
@@ -1430,35 +1373,20 @@ var toggleFieldsArray = ' . $this->toggleFields . ';
 								$right = '...';
 							}
 
-							$container = 'JQuery("body").append("<div class=\"bfCalendarResponsiveContainer' . $mdata['dbId'] . '\" style=\"display:block;position:absolute;left:-9999px;\"></div>");';
-
-							echo '<input autocomplete="off" class="ff_elem" type="text" name="ff_nm_' . $mdata['bfName'] . '[]"  id="ff_elem' . $mdata['dbId'] . '" value="' . htmlentities($left, ENT_QUOTES, 'UTF-8') . '"/>' . "\n";
+						echo '<input autocomplete="off" class="ff_elem" type="text" name="ff_nm_' . $mdata['bfName'] . '[]"  id="ff_elem' . $mdata['dbId'] . '" value="' . htmlentities($left, ENT_QUOTES, 'UTF-8') . '"/>' . "\n";
 							echo '<label for="ff_elem' . $mdata['dbId'] . '_calendarButton"></label>';
 							echo '<button data-theme="a" id="ff_elem' . $mdata['dbId'] . '_calendarButton" type="button" class="bfCalendar" value="' . htmlentities($right, ENT_QUOTES, 'UTF-8') . '"><span>' . htmlentities($right, ENT_QUOTES, 'UTF-8') . '</span></button>' . "\n";
 
-						echo '<script type="text/javascript">
-                                                <!--
-	                                                JQuery(document).ready(function () {
-	                                                    ' . $container . '
-	                                                    JQuery("#ff_elem' . $mdata['dbId'] . '_calendarButton").on("mousedown",function(event){
-	                                                    event.preventDefault();})
-	                                                    JQuery("#ff_elem' . $mdata['dbId'] . '_calendarButton").pickadate({
-	                                                        format: ' . $pickerFormat . ',
-	                                                        selectYears: ' . $pickerSelectYears . ',
-	                                                        selectMonths: true,
-	                                                        editable: true,
-	                                                        firstDay: ' . $pickerFirstDay . ',
-	                                                        container: ".bfCalendarResponsiveContainer' . $mdata['dbId'] . '",
-	                                                        onClose: function() {
-	                                                            JQuery("#ff_elem' . $mdata['dbId'] . '_calendarButton").blur();
-	                                                        },
-                                                        onSet: function() {
-                                                            JQuery("#ff_elem' . $mdata['dbId'] . '").val(this.get("value"));
-                                                        }
-                                                    });
-                                                });
-                                                //-->
-                                                </script>' . "\n";
+						if (!$this->hasResponsiveDatePicker) {
+							Factory::getApplication()->getDocument()->addScript(Uri::root(true) . '/media/com_breezingformsng/js/site/quickmode-calendar-responsive-init.js');
+						}
+
+						echo '<script type="text/javascript">bfInitCalendarResponsive(' . json_encode((int) $mdata['dbId']) . ', ' . json_encode([
+							'format' => $mdata['format'],
+							'selectYears' => $pickerSelectYears,
+							'firstDay' => $pickerFirstDay,
+							'hasYearScroller' => false,
+						]) . ');</script>' . "\n";
 
 						$this->hasResponsiveDatePicker = true;
 

--- a/components/com_breezingformsng/src/Service/Rendering/QuickMode/MobileRenderer.php
+++ b/components/com_breezingformsng/src/Service/Rendering/QuickMode/MobileRenderer.php
@@ -1373,7 +1373,7 @@ var toggleFieldsArray = ' . $this->toggleFields . ';
 								$right = '...';
 							}
 
-						echo '<input autocomplete="off" class="ff_elem" type="text" name="ff_nm_' . $mdata['bfName'] . '[]"  id="ff_elem' . $mdata['dbId'] . '" value="' . htmlentities($left, ENT_QUOTES, 'UTF-8') . '"/>' . "\n";
+							echo '<input autocomplete="off" class="ff_elem" type="text" name="ff_nm_' . $mdata['bfName'] . '[]"  id="ff_elem' . $mdata['dbId'] . '" value="' . htmlentities($left, ENT_QUOTES, 'UTF-8') . '"/>' . "\n";
 							echo '<label for="ff_elem' . $mdata['dbId'] . '_calendarButton"></label>';
 							echo '<button data-theme="a" id="ff_elem' . $mdata['dbId'] . '_calendarButton" type="button" class="bfCalendar" value="' . htmlentities($right, ENT_QUOTES, 'UTF-8') . '"><span>' . htmlentities($right, ENT_QUOTES, 'UTF-8') . '</span></button>' . "\n";
 

--- a/components/com_breezingformsng/src/Service/Rendering/QuickMode/OnePageRenderer.php
+++ b/components/com_breezingformsng/src/Service/Rendering/QuickMode/OnePageRenderer.php
@@ -1447,23 +1447,14 @@ var toggleFieldsArray = ' . $this->toggleFields . ';
 
                                 $http = 'https';
 
-                                $lang = Factory::getApplication()->getInput()->getString('lang', '');
-
                                 $getLangTag = Factory::getApplication()->getLanguage()->getTag();
                                 $getLangSlug = explode('-', $getLangTag);
                                 $reCaptchaLang = 'hl=' . $getLangSlug[0];
 
-                                if ($lang != '') {
-                                    $lang = ',lang: ' . json_encode($lang) . '';
-                                }
-                                $size = '';
-                                if ($mdata['size'] != '') {
-                                    $size = json_encode($mdata['size']);
-                                } else {
-                                    $normal = 'normal';
-                                    $size = json_encode($normal);
-                                }
+                                $size = (isset($mdata['size']) && $mdata['size'] != '') ? $mdata['size'] : 'normal';
+
                                 Factory::getApplication()->getDocument()->addScript($http . '://www.google.com/recaptcha/api.js?' . $reCaptchaLang . '&onload=onloadBFNewRecaptchaCallback&render=explicit', $type = "text/javascript", array('data-usercentrics' => 'reCAPTCHA'));
+                                Factory::getApplication()->getDocument()->addScript(Uri::root(true) . '/media/com_breezingformsng/js/site/quickmode-recaptcha-visible.js');
 
                                 echo '
                                                     <div style="display: inline-block !important; vertical-align: middle;">
@@ -1474,40 +1465,14 @@ var toggleFieldsArray = ' . $this->toggleFields . ';
                                                         </div>
                                                         <div class="g-recaptcha" data-sitekey="' . $mdata['pubkey'] . '"></div>
                                                     </div>
-                                                    <script data-usercentrics="reCAPTCHA" type="text/javascript">
-                                                    <!--
-                                                    var onloadBFNewRecaptchaCallback = function() {
-                                                      grecaptcha.render(document.getElementById("newrecaptcha"), {
-                                                        "sitekey" : "' . $mdata['pubkey'] . '",
-														"theme" : "' . (trim($mdata['theme']) == '' ? 'light' : trim($mdata['theme'])) . '",
-														"size"	: ' . $size . ',
-                                                      });
-                                                    };
-                                                    JQuery(document).ready(function(){
-                                                        var rc_loaded = JQuery("script").filter(function () {
-														    return ((typeof JQuery(this).attr("src") != "undefined" && JQuery(this).attr("src").indexOf("recaptcha\/api.js") > 0) ? true : false);
-														}).length;
-
-														if (rc_loaded === 0) {
-															//JQuery.getScript("' . $http . '://www.google.com/recaptcha/api.js?' . $reCaptchaLang . '&onload=onloadBFNewRecaptchaCallback&render=explicit");
-														}
-                                                    });
-                                                    -->
-                                                  </script>';
+                                                    <script data-usercentrics="reCAPTCHA" type="text/javascript">bfInitVisibleReCaptcha(' . json_encode([
+                                    'sitekey' => $mdata['pubkey'],
+                                    'theme' => trim($mdata['theme']) == '' ? 'light' : trim($mdata['theme']),
+                                    'size' => $size,
+                                    'resetOnRerender' => false,
+                                ]) . ');</script>';
                             } else
                                 if (isset($mdata['invisibleCaptcha']) && $mdata['invisibleCaptcha']) {
-
-                                    $http = 'https';
-
-                                    $lang = Factory::getApplication()->getInput()->getString('lang', '');
-                                    if ($lang != '') {
-                                        $lang = ',lang: ' . json_encode($lang) . '';
-                                    }
-
-                                    $callSubmit = 'ff_validate_submit(this, \'click\')';
-                                    if ($this->hasFlashUpload) {
-                                        $callSubmit = 'if(typeof bfAjaxObject101 == \'undefined\' && typeof bfReCaptchaLoaded == \'undefined\'){bfDoFlashUpload()}else{ff_validate_submit(this, \'click\')}';
-                                    }
 
                                     $badge = str_replace('invisible_', '', trim($mdata['theme']));
 
@@ -1529,36 +1494,14 @@ var toggleFieldsArray = ' . $this->toggleFields . ';
                                         ';
                                     }
 
-                                    echo '
-                                                    <script data-usercentrics="reCAPTCHA" type="text/javascript">
-                                                    <!--
-                                                    bfInvisibleRecaptcha = true;
-                                                    var onloadBFNewRecaptchaCallback = function() {
-                                                      grecaptcha.render("bfInvisibleReCaptchaContainer", {
-                                                        "sitekey" : "' . $mdata['pubkey'] . '",
-                                                        "expired-callback": recaptchaExpiredCallback,
-                                                        "size": "invisible",
-                                                        "badge" : "' . ($badge == 'red' ? '' : $badge) . '",
-                                                        "callback" : function(){if(typeof bf_htmltextareainit != \'undefined\'){ bf_htmltextareainit() }' . $callSubmit . ' }
-                                                      });
-                                                    };
-                                                    
-                                                   function recaptchaExpiredCallback(){
-                                                        grecaptcha.reset();
-                                                    };     
+                                    Factory::getApplication()->getDocument()->addScript(Uri::root(true) . '/media/com_breezingformsng/js/site/quickmode-recaptcha-invisible.js');
 
-                                                    JQuery(document).ready(function(){
-
-                                                        var rc_loaded = JQuery("script").filter(function () {
-														    return ((typeof JQuery(this).attr("src") != "undefined" && JQuery(this).attr("src").indexOf("recaptcha\/api.js") > 0) ? true : false);
-														}).length;
-
-														if (rc_loaded === 0) {
-															//JQuery.getScript("' . $http . '://www.google.com/recaptcha/api.js?onload=onloadBFNewRecaptchaCallback&render=explicit");
-														}
-                                                    });
-                                                    -->
-                                                  </script>
+                                    echo '<script data-usercentrics="reCAPTCHA" type="text/javascript">bfInitInvisibleReCaptcha(' . json_encode([
+                                        'sitekey' => $mdata['pubkey'],
+                                        'badge' => $badge == 'red' ? '' : $badge,
+                                        'hasFlashUpload' => $this->hasFlashUpload,
+                                        'resetFlagOnCallback' => false,
+                                    ]) . ');</script>
                                                   <script data-usercentrics="reCAPTCHA" src="https://www.google.com/recaptcha/api.js?onload=onloadBFNewRecaptchaCallback&render=explicit" async defer></script>
                                                   ';
                                 }
@@ -1724,7 +1667,6 @@ var toggleFieldsArray = ' . $this->toggleFields . ';
                         $mdata['format'] = $this->bfCalendarToPickadateFormat($mdata['format']);
                         $pickerFirstDay = $this->bfCalendarToPickadateFirstDay(isset($mdata['firstDay']) ? $mdata['firstDay'] : '');
                         $pickerSelectYears = $this->bfCalendarSelectYears($mdata);
-                        $pickerFormat = json_encode($mdata['format']);
                         echo '<div class="' . $this->bsClass('controls') . ' ' . $this->bsClass('form-inline') . '">';
                         echo '<div class="' . $this->bsClass('form-group') . ' ' . $this->bsClass('other-form-group') . '">';
                         echo $label;
@@ -1755,42 +1697,21 @@ var toggleFieldsArray = ' . $this->toggleFields . ';
                         echo '<button style="cursor:pointer !important;" type="button" id="ff_elem' . $mdata['dbId'] . '_calendarButton" class="bfCalendar ' . $this->bsClass('btn') . ' ' . $this->bsClass('btn-primary') . ' button" value="' . htmlentities($right, ENT_QUOTES, 'UTF-8') . '"><i class="' . $this->bsClass('icon-calendar') . '"></i>' . htmlentities($right == '...' ? '' : $right, ENT_QUOTES, 'UTF-8') . '</button>' . "\n";
                         echo '</div>' . "\n";
 
-                        $container = 'JQuery("body").append("<div class=\"bfCalendarResponsiveContainer' . $mdata['dbId'] . '\" style=\"display:block;position:absolute;left:-9999px;\"></div>");';
-
                         if (!$this->hasResponsiveDatePicker) {
                             Factory::getApplication()->getDocument()->getWebAssetManager()->addInlineScript(
                                 'var bfPickerMinusYearIcon = ' . json_encode(Uri::root(true) . '/components/com_breezingformsng/libraries/jquery/pickadate/minusyear.png') . ';'
                                 . "\n" . 'var bfPickerPlusYearIcon = ' . json_encode(Uri::root(true) . '/components/com_breezingformsng/libraries/jquery/pickadate/plusyear.png') . ';'
                             );
                             Factory::getApplication()->getDocument()->addScript(Uri::root(true) . '/media/com_breezingformsng/js/site/quickmode-calendar-responsive-legacy-style.js');
+                            Factory::getApplication()->getDocument()->addScript(Uri::root(true) . '/media/com_breezingformsng/js/site/quickmode-calendar-responsive-init.js');
                         }
 
-                        echo '<script type="text/javascript">
-                                                <!--
-                                                JQuery(document).ready(function () {
-                                                    ' . $container . '
-                                                    JQuery("#ff_elem' . $mdata['dbId'] . '_calendarButton").on("mousedown",function(event){
-                                                    event.preventDefault();})
-                                                    JQuery("#ff_elem' . $mdata['dbId'] . '_calendarButton").pickadate({
-                                                        format: ' . $pickerFormat . ',
-                                                        selectYears: ' . $pickerSelectYears . ',
-                                                        selectMonths: true,
-                                                        editable: true,
-                                                        firstDay: ' . $pickerFirstDay . ',
-                                                        container: ".bfCalendarResponsiveContainer' . $mdata['dbId'] . '",
-                                                        onClose: function() {
-                                                            JQuery("#ff_elem' . $mdata['dbId'] . '_calendarButton").blur();
-                                                        },
-                                                        onOpen: function() {
-                                                            bf_add_yearscroller( ' . json_encode($mdata['dbId']) . ' );
-                                                        },
-                                                        onSet: function() {
-                                                            JQuery("#ff_elem' . $mdata['dbId'] . '").val(this.get("value"));
-                                                        }
-                                                    });
-                                                });
-                                                //-->
-                                                </script>' . "\n";
+                        echo '<script type="text/javascript">bfInitCalendarResponsive(' . json_encode((int) $mdata['dbId']) . ', ' . json_encode([
+                            'format' => $mdata['format'],
+                            'selectYears' => $pickerSelectYears,
+                            'firstDay' => $pickerFirstDay,
+                            'hasYearScroller' => true,
+                        ]) . ');</script>' . "\n";
 
                         $this->hasResponsiveDatePicker = true;
 

--- a/media/com_breezingformsng/js/site/quickmode-calendar-responsive-init.js
+++ b/media/com_breezingformsng/js/site/quickmode-calendar-responsive-init.js
@@ -1,0 +1,36 @@
+/* Extracted from BFQuickMode's inline process() script (Phase 9c step 2b,
+   bfCalendarResponsive case) - the pickadate() initializer bound to each
+   responsive calendar field. Only the per-field config (dbId, pickadate
+   format/selectYears/firstDay, and whether the year-scroller buttons are
+   available on this theme) is dynamic; everything else was byte-identical
+   across ClassicRenderer/BootstrapRenderer/OnePageRenderer, and
+   MobileRenderer's only difference was the missing onOpen year-scroller
+   hook (no bf_add_yearscroller asset loaded on that theme). Called once per
+   field right after it is rendered. */
+function bfInitCalendarResponsive(dbId, options) {
+	JQuery(document).ready(function () {
+		JQuery('body').append('<div class="bfCalendarResponsiveContainer' + dbId + '" style="display:block;position:absolute;left:-9999px;"></div>');
+		JQuery('#ff_elem' + dbId + '_calendarButton').on('mousedown', function (event) {
+			event.preventDefault();
+		});
+		JQuery('#ff_elem' + dbId + '_calendarButton').pickadate({
+			format: options.format,
+			selectYears: options.selectYears,
+			selectMonths: true,
+			editable: true,
+			firstDay: options.firstDay,
+			container: '.bfCalendarResponsiveContainer' + dbId,
+			onClose: function () {
+				JQuery('#ff_elem' + dbId + '_calendarButton').blur();
+			},
+			onOpen: function () {
+				if (options.hasYearScroller) {
+					bf_add_yearscroller(dbId);
+				}
+			},
+			onSet: function () {
+				JQuery('#ff_elem' + dbId).val(this.get('value'));
+			}
+		});
+	});
+}

--- a/media/com_breezingformsng/js/site/quickmode-recaptcha-invisible-mobile.js
+++ b/media/com_breezingformsng/js/site/quickmode-recaptcha-invisible-mobile.js
@@ -1,0 +1,45 @@
+/* Extracted from BFQuickMode's inline process() script (Phase 9c step 2b,
+   bfReCaptcha case, invisible-captcha variant, Mobile theme only). Unlike
+   Classic/Bootstrap/OnePage (quickmode-recaptcha-invisible.js), this theme
+   builds the captcha containers dynamically via jQuery instead of echoing
+   static markup, hides the field's own wrapper (jQuery Mobile lays out
+   captcha differently), never defines an expired-callback, and hardcodes
+   badge "inline". Preserved as-is rather than merged into the shared
+   file. */
+function bfInitInvisibleReCaptchaMobile(options) {
+	window.bfInvisibleRecaptcha = true;
+
+	function bfCallReCaptchaSubmit() {
+		if (options.hasFlashUpload) {
+			if (typeof bfAjaxObject101 == 'undefined' && typeof bfReCaptchaLoaded == 'undefined') {
+				bfDoFlashUpload();
+			} else {
+				ff_validate_submit(this, 'click');
+			}
+		} else {
+			ff_validate_submit(this, 'click');
+		}
+	}
+
+	window.onloadBFNewRecaptchaCallback = function () {
+		grecaptcha.render('bfInvisibleReCaptchaContainer', {
+			sitekey: options.sitekey,
+			size: 'invisible',
+			theme: options.theme,
+			badge: 'inline',
+			callback: function () {
+				if (typeof bf_htmltextareainit != 'undefined') {
+					bf_htmltextareainit();
+				}
+				bfCallReCaptchaSubmit();
+			}
+		});
+	};
+
+	JQuery(document).ready(function () {
+		JQuery('#bfElemWrap' + options.dbId).css('display', 'none');
+		JQuery('#' + options.formId).append(
+			'<div id="bfInvisibleReCaptchaContainer"></div><div id="bfInvisibleReCaptcha" class="g-recaptcha" data-callback="onloadBFNewRecaptchaCallback" data-size="invisible" data-sitekey="' + options.sitekey + '"></div>'
+		);
+	});
+}

--- a/media/com_breezingformsng/js/site/quickmode-recaptcha-invisible.js
+++ b/media/com_breezingformsng/js/site/quickmode-recaptcha-invisible.js
@@ -1,0 +1,52 @@
+/* Extracted from BFQuickMode's inline process() script (Phase 9c step 2b,
+   bfReCaptcha case, invisible-captcha variant). Identical between
+   ClassicRenderer and BootstrapRenderer. OnePageRenderer's callback never
+   reset window.bfInvisibleRecaptcha back to false on a successful check
+   (it used an inline anonymous callback instead of the named
+   recaptchaCheckedCallback the other two themes define) - a real,
+   pre-existing behavioral difference, preserved here via
+   `resetFlagOnCallback` rather than silently unified. MobileRenderer is
+   not covered by this file: it builds the captcha containers dynamically
+   via jQuery instead of echoing static markup, hides the field's wrapper,
+   omits the expired-callback, and hardcodes badge "inline" - different
+   enough to warrant its own file (quickmode-recaptcha-invisible-mobile.js)
+   rather than a forced merge. */
+function bfInitInvisibleReCaptcha(options) {
+	window.bfInvisibleRecaptcha = true;
+
+	function bfCallReCaptchaSubmit() {
+		if (options.hasFlashUpload) {
+			if (typeof bfAjaxObject101 == 'undefined' && typeof bfReCaptchaLoaded == 'undefined') {
+				bfDoFlashUpload();
+			} else {
+				ff_validate_submit(this, 'click');
+			}
+		} else {
+			ff_validate_submit(this, 'click');
+		}
+	}
+
+	function recaptchaCheckedCallback(token) {
+		if (options.resetFlagOnCallback && token != '') {
+			window.bfInvisibleRecaptcha = false;
+		}
+		if (typeof bf_htmltextareainit != 'undefined') {
+			bf_htmltextareainit();
+		}
+		bfCallReCaptchaSubmit();
+	}
+
+	window.recaptchaExpiredCallback = function () {
+		grecaptcha.reset();
+	};
+
+	window.onloadBFNewRecaptchaCallback = function () {
+		grecaptcha.render('bfInvisibleReCaptchaContainer', {
+			sitekey: options.sitekey,
+			'expired-callback': recaptchaExpiredCallback,
+			callback: recaptchaCheckedCallback,
+			badge: options.badge,
+			size: 'invisible'
+		});
+	};
+}

--- a/media/com_breezingformsng/js/site/quickmode-recaptcha-visible.js
+++ b/media/com_breezingformsng/js/site/quickmode-recaptcha-visible.js
@@ -1,0 +1,34 @@
+/* Extracted from BFQuickMode's inline process() script (Phase 9c step 2b,
+   bfReCaptcha case, visible/checkbox variant). Byte-identical across
+   ClassicRenderer/BootstrapRenderer/MobileRenderer/OnePageRenderer except
+   one flag: ClassicRenderer's grecaptcha.render() call passes a second
+   `true` argument (undocumented, kept as `resetOnRerender` below since the
+   other three themes never passed it and this document has no record of
+   why Classic alone does). Only the sitekey/theme/size and that flag are
+   dynamic; everything else (the script-already-loaded guard) was
+   duplicated verbatim in all four files. */
+function bfInitVisibleReCaptcha(options) {
+	var onloadBFNewRecaptchaCallback = function () {
+		var config = {
+			sitekey: options.sitekey,
+			theme: options.theme,
+			size: options.size
+		};
+		if (options.resetOnRerender) {
+			grecaptcha.render(document.getElementById('newrecaptcha'), config, true);
+		} else {
+			grecaptcha.render(document.getElementById('newrecaptcha'), config);
+		}
+	};
+	window.onloadBFNewRecaptchaCallback = onloadBFNewRecaptchaCallback;
+
+	JQuery(document).ready(function () {
+		var rc_loaded = JQuery('script').filter(function () {
+			return (typeof JQuery(this).attr('src') != 'undefined' && JQuery(this).attr('src').indexOf('recaptcha/api.js') > 0);
+		}).length;
+
+		if (rc_loaded === 0) {
+			// historically a no-op here too: JQuery.getScript(...) was commented out in all four renderers
+		}
+	});
+}


### PR DESCRIPTION
## Résumé

Phase 9c : extraction de trois blocs `<script>` inline *par élément* (calendrier responsive, reCAPTCHA visible et invisible) des 4 renderers `BFQuickMode*` vers des assets JS statiques partagés.

- **Calendrier responsive** (`bfCalendarResponsive`) — initialiseur `pickadate()` extrait vers `quickmode-calendar-responsive-init.js`, appelé avec un objet de config JSON par champ.
- **reCAPTCHA visible** — extrait vers `quickmode-recaptcha-visible.js`, identique sur les 4 thèmes à un flag près (`resetOnRerender`, propre à Classic, préservé).
- **reCAPTCHA invisible** — une vraie divergence de comportement a été trouvée entre thèmes (OnePage ne réinitialise jamais un flag que Classic/Bootstrap réinitialisent ; Mobile construit ses conteneurs différemment via jQuery). Plutôt que de forcer une unification, extraction en deux fichiers : `quickmode-recaptcha-invisible.js` (partagé Classic/Bootstrap/OnePage, avec un flag `resetFlagOnCallback` documentant la divergence OnePage) et `quickmode-recaptcha-invisible-mobile.js` (dédié).

Aucun changement de comportement voulu — seulement une relocalisation du JS, avec les divergences réelles préservées et documentées plutôt que corrigées silencieusement.

## Contexte

Aucun formulaire publié sur le site de dev n'exerçait de champ reCAPTCHA, rendant impossible toute vérification en conditions réelles. Deux formulaires de test **permanents** ont été créés en base (clé de test Google officielle, publique, sans risque) :

- `PermanentReCaptchaTest` (id 86) — reCAPTCHA visible
- `PermanentReCaptchaInvisibleTest` (id 87) — reCAPTCHA invisible, badge inline

Ces formulaires ne doivent **pas être supprimés** : ils permettent de revérifier ces chemins dans de futures sessions sans setup supplémentaire.

## Vérifications effectuées

- [x] `php -l` propre sur les 4 renderers
- [x] `node --check` propre sur les 4 nouveaux fichiers JS
- [x] Calendrier responsive vérifié en direct (formulaire 28, Bootstrap) : ouverture du picker déclenche bien le year-scroller, zéro erreur console
- [x] reCAPTCHA visible vérifié en direct (formulaire 86, Bootstrap) : widget rendu, 2 iframes Google, zéro erreur console
- [x] reCAPTCHA invisible vérifié en direct sur **Bootstrap et OnePage** (formulaire 87, basculé temporairement puis restauré) : flag `resetFlagOnCallback` correctement différencié entre les deux thèmes, zéro erreur console
- [ ] reCAPTCHA invisible sur **Mobile** : non vérifiable en direct — le rendu Mobile dépend de `bf_is_mobile()` côté serveur, qui ne se laisse pas déclencher par un simple en-tête `User-Agent` Playwright (limitation déjà documentée dans MIGRATION.md). Vérifié par lecture de code uniquement.
- [ ] Classic et Mobile pour le calendrier responsive et le reCAPTCHA visible : vérifiés par lecture de code uniquement (mêmes patrons que Bootstrap/OnePage, pas de champ de test dédié sur ces thèmes)

## Fichiers

**Modifiés**
- `components/com_breezingformsng/src/Service/Rendering/QuickMode/{Classic,Bootstrap,Mobile,OnePage}Renderer.php`

**Ajoutés**
- `media/com_breezingformsng/js/site/quickmode-calendar-responsive-init.js`
- `media/com_breezingformsng/js/site/quickmode-recaptcha-visible.js`
- `media/com_breezingformsng/js/site/quickmode-recaptcha-invisible.js`
- `media/com_breezingformsng/js/site/quickmode-recaptcha-invisible-mobile.js`

**Documentation**
- `MIGRATION.md` mis à jour (Phase 9c)
